### PR TITLE
Remove the path specifications

### DIFF
--- a/actions/setup.go
+++ b/actions/setup.go
@@ -1,12 +1,13 @@
 package actions
 
 import (
+	"time"
+
 	"github.com/avast/retry-go"
 	"github.com/smartcontractkit/integrations-framework/client"
 	"github.com/smartcontractkit/integrations-framework/config"
 	"github.com/smartcontractkit/integrations-framework/contracts"
 	"github.com/smartcontractkit/integrations-framework/environment"
-	"time"
 )
 
 type DefaultSuiteSetup struct {
@@ -23,7 +24,7 @@ func DefaultLocalSetup(
 	envInitFunc environment.K8sEnvSpecInit,
 	initFunc client.BlockchainNetworkInit,
 ) (*DefaultSuiteSetup, error) {
-	conf, err := config.NewWithPath(config.LocalConfig, "../../config")
+	conf, err := config.NewConfig(config.LocalConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/client/blockchain_test.go
+++ b/client/blockchain_test.go
@@ -13,7 +13,7 @@ var _ = Describe("Client", func() {
 
 	BeforeEach(func() {
 		var err error
-		conf, err = config.NewWithPath(config.LocalConfig, "../config")
+		conf, err = config.NewConfig(config.LocalConfig)
 		Expect(err).ShouldNot(HaveOccurred())
 	})
 

--- a/config/config.go
+++ b/config/config.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/smartcontractkit/integrations-framework/internal"
+	"github.com/smartcontractkit/integrations-framework/tools"
 	"github.com/spf13/viper"
 )
 
@@ -57,7 +57,7 @@ func NewConfig(configType ConfigurationType) (*Config, error) {
 	v.AutomaticEnv()
 	v.SetConfigName("config")
 	v.SetConfigType("yml")
-	v.AddConfigPath(filepath.Join(internal.ProjectRoot, "config"))
+	v.AddConfigPath(filepath.Join(tools.ProjectRoot, "config"))
 
 	if err := v.ReadInConfig(); err != nil {
 		return nil, err

--- a/config/config.go
+++ b/config/config.go
@@ -3,9 +3,11 @@ package config
 
 import (
 	"errors"
+	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/smartcontractkit/integrations-framework/internal"
 	"github.com/spf13/viper"
 )
 
@@ -50,21 +52,12 @@ type NetworkConfig struct {
 
 // NewConfig creates a new configuration instance via viper from env vars, config file, or a secret store
 func NewConfig(configType ConfigurationType) (*Config, error) {
-	return NewWithPath(configType, "")
-}
-
-// NewWithPath creates a new configuration with a specified path for the config file
-func NewWithPath(configType ConfigurationType, configFilePath string) (*Config, error) {
 	v := viper.New()
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	v.AutomaticEnv()
 	v.SetConfigName("config")
 	v.SetConfigType("yml")
-
-	if len(configFilePath) == 0 {
-		configFilePath = "./" // Use default
-	}
-	v.AddConfigPath(configFilePath)
+	v.AddConfigPath(filepath.Join(internal.ProjectRoot, "config"))
 
 	if err := v.ReadInConfig(); err != nil {
 		return nil, err

--- a/environment/environment_templates.go
+++ b/environment/environment_templates.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/smartcontractkit/integrations-framework/config"
-	"github.com/smartcontractkit/integrations-framework/internal"
+	"github.com/smartcontractkit/integrations-framework/tools"
 	coreV1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -21,8 +21,8 @@ const (
 func NewAdapterManifest() *K8sManifest {
 	return &K8sManifest{
 		id:             "adapter",
-		DeploymentFile: filepath.Join(internal.ProjectRoot, "/environment/templates/adapter-deployment.yml"),
-		ServiceFile:    filepath.Join(internal.ProjectRoot, "/environment/templates/adapter-service.yml"),
+		DeploymentFile: filepath.Join(tools.ProjectRoot, "/environment/templates/adapter-deployment.yml"),
+		ServiceFile:    filepath.Join(tools.ProjectRoot, "/environment/templates/adapter-service.yml"),
 
 		values: map[string]interface{}{
 			"apiPort": AdapterAPIPort,
@@ -50,8 +50,8 @@ func NewAdapterManifest() *K8sManifest {
 func NewChainlinkManifest() *K8sManifest {
 	return &K8sManifest{
 		id:             "chainlink",
-		DeploymentFile: filepath.Join(internal.ProjectRoot, "/environment/templates/chainlink-deployment.yml"),
-		ServiceFile:    filepath.Join(internal.ProjectRoot, "/environment/templates/chainlink-service.yml"),
+		DeploymentFile: filepath.Join(tools.ProjectRoot, "/environment/templates/chainlink-deployment.yml"),
+		ServiceFile:    filepath.Join(tools.ProjectRoot, "/environment/templates/chainlink-service.yml"),
 
 		values: map[string]interface{}{
 			"webPort": ChainlinkWebPort,
@@ -75,8 +75,8 @@ func NewChainlinkManifest() *K8sManifest {
 func NewHardhatManifest() *K8sManifest {
 	return &K8sManifest{
 		id:             "hardhat",
-		DeploymentFile: filepath.Join(internal.ProjectRoot, "/environment/templates/hardhat-deployment.yml"),
-		ServiceFile:    filepath.Join(internal.ProjectRoot, "/environment/templates/hardhat-service.yml"),
+		DeploymentFile: filepath.Join(tools.ProjectRoot, "/environment/templates/hardhat-deployment.yml"),
+		ServiceFile:    filepath.Join(tools.ProjectRoot, "/environment/templates/hardhat-service.yml"),
 
 		values: map[string]interface{}{
 			"rpcPort": EVMRPCPort,

--- a/environment/environment_templates.go
+++ b/environment/environment_templates.go
@@ -2,13 +2,10 @@ package environment
 
 import (
 	"fmt"
-	"os/exec"
 	"path/filepath"
-	"strings"
-
-	"github.com/rs/zerolog/log"
 
 	"github.com/smartcontractkit/integrations-framework/config"
+	"github.com/smartcontractkit/integrations-framework/internal"
 	coreV1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -24,8 +21,8 @@ const (
 func NewAdapterManifest() *K8sManifest {
 	return &K8sManifest{
 		id:             "adapter",
-		DeploymentFile: filepath.Join(getDirectoryRoot(), "/environment/templates/adapter-deployment.yml"),
-		ServiceFile:    filepath.Join(getDirectoryRoot(), "/environment/templates/adapter-service.yml"),
+		DeploymentFile: filepath.Join(internal.ProjectRoot, "/environment/templates/adapter-deployment.yml"),
+		ServiceFile:    filepath.Join(internal.ProjectRoot, "/environment/templates/adapter-service.yml"),
 
 		values: map[string]interface{}{
 			"apiPort": AdapterAPIPort,
@@ -53,8 +50,8 @@ func NewAdapterManifest() *K8sManifest {
 func NewChainlinkManifest() *K8sManifest {
 	return &K8sManifest{
 		id:             "chainlink",
-		DeploymentFile: filepath.Join(getDirectoryRoot(), "/environment/templates/chainlink-deployment.yml"),
-		ServiceFile:    filepath.Join(getDirectoryRoot(), "/environment/templates/chainlink-service.yml"),
+		DeploymentFile: filepath.Join(internal.ProjectRoot, "/environment/templates/chainlink-deployment.yml"),
+		ServiceFile:    filepath.Join(internal.ProjectRoot, "/environment/templates/chainlink-service.yml"),
 
 		values: map[string]interface{}{
 			"webPort": ChainlinkWebPort,
@@ -78,8 +75,8 @@ func NewChainlinkManifest() *K8sManifest {
 func NewHardhatManifest() *K8sManifest {
 	return &K8sManifest{
 		id:             "hardhat",
-		DeploymentFile: filepath.Join(getDirectoryRoot(), "/environment/templates/hardhat-deployment.yml"),
-		ServiceFile:    filepath.Join(getDirectoryRoot(), "/environment/templates/hardhat-service.yml"),
+		DeploymentFile: filepath.Join(internal.ProjectRoot, "/environment/templates/hardhat-deployment.yml"),
+		ServiceFile:    filepath.Join(internal.ProjectRoot, "/environment/templates/hardhat-service.yml"),
 
 		values: map[string]interface{}{
 			"rpcPort": EVMRPCPort,
@@ -122,12 +119,4 @@ func NewChainlinkCluster(nodeCount int) K8sEnvSpecInit {
 		}
 		return envName, envWithHardhat
 	}
-}
-
-func getDirectoryRoot() string {
-	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
-	if err != nil {
-		log.Err(err).Msg("Error retrieving project root directory via 'git rev-parse --show-toplevel'")
-	}
-	return strings.TrimSpace(string(out))
 }

--- a/environment/k8s_environment.go
+++ b/environment/k8s_environment.go
@@ -4,10 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/avast/retry-go"
-	"github.com/hashicorp/go-multierror"
-	"github.com/smartcontractkit/integrations-framework/config"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -15,6 +11,11 @@ import (
 	"sync"
 	"text/template"
 	"time"
+
+	"github.com/avast/retry-go"
+	"github.com/hashicorp/go-multierror"
+	"github.com/smartcontractkit/integrations-framework/config"
+	"gopkg.in/yaml.v2"
 
 	"github.com/rs/zerolog/log"
 	"github.com/smartcontractkit/integrations-framework/client"
@@ -601,7 +602,7 @@ func (m *K8sManifest) forwardPodPorts(pod *coreV1.Pod) ([]portforward.ForwardedP
 	}
 	if len(out.String()) > 0 {
 		msg := strings.ReplaceAll(out.String(), "\n", " ")
-		log.Debug().Str("Pod", pod.Name).Msgf("Debug message on port forward: %s", msg)
+		log.Debug().Str("Pod", pod.Name).Msgf("%s", msg)
 	}
 
 	m.stopChannels = append(m.stopChannels, stopChan)

--- a/environment/k8s_environment_test.go
+++ b/environment/k8s_environment_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Environment functionality", func() {
 		}
 		Expect(err).ShouldNot(HaveOccurred())
 	},
-		Entry("1 node cluster", client.NewNetworkFromConfig, NewChainlinkCluster("../", 1), 1),
-		Entry("5 node cluster", client.NewNetworkFromConfig, NewChainlinkCluster("../", 5), 5),
+		Entry("1 node cluster", client.NewNetworkFromConfig, NewChainlinkCluster(1), 1),
+		Entry("5 node cluster", client.NewNetworkFromConfig, NewChainlinkCluster(5), 5),
 	)
 })

--- a/environment/k8s_environment_test.go
+++ b/environment/k8s_environment_test.go
@@ -15,7 +15,7 @@ var _ = Describe("Environment functionality", func() {
 
 	BeforeEach(func() {
 		var err error
-		conf, err = config.NewWithPath(config.LocalConfig, "../config")
+		conf, err = config.NewConfig(config.LocalConfig)
 		Expect(err).ShouldNot(HaveOccurred())
 	})
 

--- a/internal/project_path.go
+++ b/internal/project_path.go
@@ -1,0 +1,12 @@
+package internal
+
+import (
+	"path/filepath"
+	"runtime"
+)
+
+var (
+	_, b, _, _ = runtime.Caller(0)
+	// Root folder of this project
+	ProjectRoot = filepath.Join(filepath.Dir(b), "/..")
+)

--- a/suite/contracts/contracts_cron_test.go
+++ b/suite/contracts/contracts_cron_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Cronjob suite", func() {
 	},
 		Entry(
 			"on Ethereum Hardhat",
-			environment.NewChainlinkCluster("../../", 1),
+			environment.NewChainlinkCluster(1),
 			client.NewNetworkFromConfig,
 			contracts.DefaultOffChainAggregatorOptions(),
 		),

--- a/suite/contracts/contracts_runlog_test.go
+++ b/suite/contracts/contracts_runlog_test.go
@@ -3,6 +3,9 @@ package contracts
 import (
 	"context"
 	"errors"
+	"math/big"
+	"strings"
+
 	"github.com/avast/retry-go"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -13,8 +16,6 @@ import (
 	"github.com/smartcontractkit/integrations-framework/client"
 	"github.com/smartcontractkit/integrations-framework/contracts"
 	"github.com/smartcontractkit/integrations-framework/environment"
-	"math/big"
-	"strings"
 )
 
 var _ = Describe("Direct request suite", func() {
@@ -94,7 +95,7 @@ var _ = Describe("Direct request suite", func() {
 	},
 		Entry(
 			"on Ethereum Hardhat",
-			environment.NewChainlinkCluster("../../", 1),
+			environment.NewChainlinkCluster(1),
 			client.NewNetworkFromConfig,
 			contracts.DefaultFluxAggregatorOptions(),
 		),

--- a/suite/contracts/contracts_test.go
+++ b/suite/contracts/contracts_test.go
@@ -2,9 +2,10 @@ package contracts
 
 import (
 	"context"
-	"github.com/smartcontractkit/integrations-framework/actions"
 	"math/big"
 	"time"
+
+	"github.com/smartcontractkit/integrations-framework/actions"
 
 	"github.com/smartcontractkit/integrations-framework/config"
 	"github.com/smartcontractkit/integrations-framework/contracts"
@@ -34,7 +35,7 @@ var _ = Describe("OCR Feed", func() {
 		// Setup
 		network, err := initFunc(conf)
 		Expect(err).ShouldNot(HaveOccurred())
-		env, err := environment.NewK8sEnvironment(environment.NewChainlinkCluster("../../", 7), conf, network)
+		env, err := environment.NewK8sEnvironment(environment.NewChainlinkCluster(7), conf, network)
 		Expect(err).ShouldNot(HaveOccurred())
 		defer env.TearDown()
 

--- a/suite/contracts/contracts_test.go
+++ b/suite/contracts/contracts_test.go
@@ -24,7 +24,7 @@ var _ = Describe("OCR Feed", func() {
 
 	BeforeEach(func() {
 		var err error
-		conf, err = config.NewWithPath(config.LocalConfig, "../../config")
+		conf, err = config.NewConfig(config.LocalConfig)
 		Expect(err).ShouldNot(HaveOccurred())
 	})
 

--- a/suite/refill/eth_refill_test.go
+++ b/suite/refill/eth_refill_test.go
@@ -2,6 +2,10 @@ package refill
 
 import (
 	"context"
+	"math/big"
+	"strings"
+	"time"
+
 	"github.com/ethereum/go-ethereum/common"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -10,9 +14,6 @@ import (
 	"github.com/smartcontractkit/integrations-framework/client"
 	"github.com/smartcontractkit/integrations-framework/contracts"
 	"github.com/smartcontractkit/integrations-framework/environment"
-	"math/big"
-	"strings"
-	"time"
 )
 
 var _ = Describe("FluxAggregator ETH Refill", func() {
@@ -26,7 +27,7 @@ var _ = Describe("FluxAggregator ETH Refill", func() {
 	BeforeSuite(func() {
 		By("Deploying the environment", func() {
 			s, err = actions.DefaultLocalSetup(
-				environment.NewChainlinkCluster("../../", 3),
+				environment.NewChainlinkCluster(3),
 				client.NewNetworkFromConfig,
 			)
 			Expect(err).ShouldNot(HaveOccurred())

--- a/tools/project_path.go
+++ b/tools/project_path.go
@@ -1,4 +1,4 @@
-package internal
+package tools
 
 import (
 	"path/filepath"


### PR DESCRIPTION
Uses the `git` command line to get the project's root directory. This gets rid of specifying the path for launching chainlink envs.

```go
NewChainlinkCluster("../../", 1) // This is no more
NewChainlinkCluster(1) // New usage
```