### PR TITLE
Support for keepEnvironments config toggle

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -21,10 +21,11 @@ const (
 
 // Config is the overall config for the framework, holding configurations for supported networks
 type Config struct {
-	Network         string                    `mapstructure:"network" yaml:"network"`
-	Networks        map[string]*NetworkConfig `mapstructure:"networks" yaml:"networks"`
-	Retry           *RetryConfig              `mapstructure:"retry" yaml:"retry"`
-	DefaultKeyStore string
+	Network          string                    `mapstructure:"network" yaml:"network"`
+	Networks         map[string]*NetworkConfig `mapstructure:"networks" yaml:"networks"`
+	Retry            *RetryConfig              `mapstructure:"retry" yaml:"retry"`
+	KeepEnvironments string                    `mapstructure:"keep_environments" yaml:"keep_environments"`
+	DefaultKeyStore  string
 }
 
 // GetNetworkConfig finds a specified network config based on its name

--- a/config/config.yml
+++ b/config/config.yml
@@ -1,6 +1,7 @@
 # Retains default and configurable name-values for the integration framework
 
 network: "ethereum_hardhat" # Selected network for test execution
+keep_environments: Never # Options: Always, OnFail, Never
 networks:
     ethereum_hardhat:
         name: "Ethereum Hardhat"

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -9,6 +9,8 @@ import (
 
 // Environment is the interface that represents a deployed environment, whether locally or on remote machines
 type Environment interface {
+	ID() string
+
 	GetLocalPorts(remotePort uint16) ([]uint16, error)
 	GetLocalPort(remotePort uint16) (uint16, error)
 	GetRemoteURLs(remotePort uint16) ([]*url.URL, error)

--- a/environment/k8s_environment.go
+++ b/environment/k8s_environment.go
@@ -99,6 +99,9 @@ func NewK8sEnvironment(
 
 	environmentName, deployables := init(network.Config())
 	namespace, err := env.createNamespace(environmentName)
+	if err != nil {
+		return nil, err
+	}
 	env.namespace = namespace
 	env.specs = deployables
 
@@ -106,6 +109,14 @@ func NewK8sEnvironment(
 		return nil, err
 	}
 	return env, err
+}
+
+// ID returns the canonical name of the environment, which in the case of k8s is the namespace
+func (env *k8sEnvironment) ID() string {
+	if env.namespace != nil {
+		return env.namespace.Name
+	}
+	return ""
 }
 
 // GetLocalPorts returns the local ports for any given remote port, achieved via port forwarding within k8s.

--- a/suite/refill/eth_refill_test.go
+++ b/suite/refill/eth_refill_test.go
@@ -17,14 +17,16 @@ import (
 )
 
 var _ = Describe("FluxAggregator ETH Refill", func() {
-	var s *actions.DefaultSuiteSetup
-	var adapter environment.ExternalAdapter
-	var nodes []client.Chainlink
-	var nodeAddresses []common.Address
-	var err error
-	var fluxInstance contracts.FluxAggregator
+	var (
+		s             *actions.DefaultSuiteSetup
+		adapter       environment.ExternalAdapter
+		nodes         []client.Chainlink
+		nodeAddresses []common.Address
+		err           error
+		fluxInstance  contracts.FluxAggregator
+	)
 
-	BeforeSuite(func() {
+	BeforeEach(func() {
 		By("Deploying the environment", func() {
 			s, err = actions.DefaultLocalSetup(
 				environment.NewChainlinkCluster(3),
@@ -40,7 +42,7 @@ var _ = Describe("FluxAggregator ETH Refill", func() {
 		})
 	})
 
-	BeforeEach(func() {
+	JustBeforeEach(func() {
 		By("Deploying and funding the contract", func() {
 			fluxInstance, err = s.Deployer.DeployFluxAggregatorContract(
 				s.Wallets.Default(),
@@ -120,9 +122,7 @@ var _ = Describe("FluxAggregator ETH Refill", func() {
 		})
 	})
 
-	AfterSuite(func() {
-		By("Tearing down the environment", func() {
-			s.Env.TearDown()
-		})
+	AfterEach(func() {
+		By("Tearing down the environment", s.TearDown())
 	})
 })


### PR DESCRIPTION
Support for `keepEnvironments` config toggle:
```yaml
keepEnvironments: Always/OnFail/Never
```

For this to work, the environment setup and tear down has to be within `BeforeEach` and `AfterEach` as Ginkgo doesn't give visibility to whether a test passed/failed in `AfterSuite`.

Example:
```
3:33PM INF Kept environment due to test failure Namespace=basic-chainlink-sxlc7
```