### PR TITLE
Feature/OCR test fixes

### DIFF
--- a/actions/actions.go
+++ b/actions/actions.go
@@ -1,9 +1,10 @@
 package actions
 
 import (
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/smartcontractkit/integrations-framework/client"
-	"math/big"
 )
 
 // FundChainlinkNodes will fund all of the Chainlink nodes with a given amount of ETH in wei
@@ -12,7 +13,7 @@ func FundChainlinkNodes(
 	blockchain client.BlockchainClient,
 	fromWallet client.BlockchainWallet,
 	nativeAmount,
-	linkAmount *big.Int,
+	linkAmount *big.Float,
 ) error {
 	for _, cl := range nodes {
 		toAddress, err := cl.PrimaryEthAddress()

--- a/client/blockchain.go
+++ b/client/blockchain.go
@@ -19,7 +19,7 @@ const BlockchainTypeEVM = "evm"
 // of network types within the test suite
 type BlockchainClient interface {
 	Get() interface{}
-	Fund(fromWallet BlockchainWallet, toAddress string, nativeMultiplier, linkMultiplier *big.Float) error
+	Fund(fromWallet BlockchainWallet, toAddress string, nativeAmount, linkAmount *big.Float) error
 }
 
 // NewBlockchainClient returns an instantiated network client implementation based on the network configuration given

--- a/client/blockchain.go
+++ b/client/blockchain.go
@@ -19,7 +19,7 @@ const BlockchainTypeEVM = "evm"
 // of network types within the test suite
 type BlockchainClient interface {
 	Get() interface{}
-	Fund(fromWallet BlockchainWallet, toAddress string, nativeAmount, linkAmount *big.Int) error
+	Fund(fromWallet BlockchainWallet, toAddress string, nativeMultiplier, linkMultiplier *big.Float) error
 }
 
 // NewBlockchainClient returns an instantiated network client implementation based on the network configuration given

--- a/client/chainlink.go
+++ b/client/chainlink.go
@@ -44,6 +44,7 @@ type Chainlink interface {
 	ReadETHKeys() (*ETHKeys, error)
 	PrimaryEthAddress() (string, error)
 
+	RemoteIP() string
 	SetSessionCookie() error
 
 	// Used for testing
@@ -238,6 +239,11 @@ func (c *chainlink) PrimaryEthAddress() (string, error) {
 		return "", err
 	}
 	return ethKeys.Data[0].Attributes.Address, nil
+}
+
+// RemoteIP retrieves the inter-cluster IP of the chainlink node, for use with inter-node communications
+func (c *chainlink) RemoteIP() string {
+	return c.Config.RemoteIP
 }
 
 // SetSessionCookie authenticates against the Chainlink node and stores the cookie in client state

--- a/client/chainlink.go
+++ b/client/chainlink.go
@@ -16,7 +16,7 @@ import (
 var ErrNotFound = errors.New("unexpected response code, got 404")
 var ErrUnprocessableEntity = errors.New("unexpected response code, got 422")
 
-var OneLINK = big.NewFloat(1000000000000000000)
+var OneLINK = big.NewFloat(10 ^ 18)
 
 // Chainlink interface that enables interactions with a chainlink node
 type Chainlink interface {

--- a/client/chainlink.go
+++ b/client/chainlink.go
@@ -86,7 +86,7 @@ func (c *chainlink) CreateJob(spec JobSpec) (*Job, error) {
 	if err != nil {
 		return nil, err
 	}
-	log.Info().Str("Node URL", c.Config.URL).Str("Job Body", specString).Msg("Creating Job")
+	log.Info().Str("Node URL", c.Config.URL).Msg("Creating Job")
 	_, err = c.do(http.MethodPost, "/v2/jobs", &JobForm{
 		TOML: specString,
 	}, &job, http.StatusOK)

--- a/client/chainlink.go
+++ b/client/chainlink.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"math/big"
 	"net/http"
 	"strings"
 
@@ -14,6 +15,8 @@ import (
 
 var ErrNotFound = errors.New("unexpected response code, got 404")
 var ErrUnprocessableEntity = errors.New("unexpected response code, got 422")
+
+var OneLINK = big.NewFloat(1000000000000000000)
 
 // Chainlink interface that enables interactions with a chainlink node
 type Chainlink interface {

--- a/client/ethereum.go
+++ b/client/ethereum.go
@@ -17,7 +17,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-var OneEth = big.NewFloat(1000000000000000000)
+var OneEth = big.NewFloat(10 ^ 18)
 
 // EthereumClient wraps the client and the BlockChain network to interact with an EVM based Blockchain
 type EthereumClient struct {

--- a/client/ethereum.go
+++ b/client/ethereum.go
@@ -255,7 +255,7 @@ func (e *EthereumClient) WaitForTransaction(transactionHash common.Hash) error {
 			if err != nil {
 				return err
 			}
-			confirmationLog := log.Info().Str("Network", e.Network.Config().Name).
+			confirmationLog := log.Debug().Str("Network", e.Network.Config().Name).
 				Str("Block Hash", block.Hash().Hex()).
 				Str("Block Number", block.Number().String()).Str("Tx Hash", transactionHash.Hex()).
 				Int("Minimum Confirmations", minConfirmations).
@@ -269,13 +269,10 @@ func (e *EthereumClient) WaitForTransaction(transactionHash common.Hash) error {
 			}
 
 			confirmations++
-			confirmationLog.Msg("Transaction confirmed, waiting on confirmations")
 
 			if confirmations >= minConfirmations {
-				confirmationLog.Msg("Minimum confirmations met")
+				confirmationLog.Msg("Transaction Confirmations Met")
 				return err
-			} else {
-				confirmationLog.Msg("Waiting on minimum confirmations")
 			}
 		case <-time.After(timeout):
 			isConfirmed, err := e.isTxConfirmed(transactionHash)

--- a/config.yml
+++ b/config.yml
@@ -4,8 +4,8 @@
 # KEEP_ENVIRONMENTS=OnFail
 # APPS_CHAINLINK_VERSION=1.0.0
 
-network: "ethereum_hardhat" # Selected network for test execution
-keep_environments: OnFail # Options: Always, OnFail, Never
+network: "ethereum_geth" # Selected network for test execution
+keep_environments: Never # Options: Always, OnFail, Never
 
 apps:
     chainlink:

--- a/config.yml
+++ b/config.yml
@@ -4,8 +4,8 @@
 # KEEP_ENVIRONMENTS=OnFail
 # APPS_CHAINLINK_VERSION=1.0.0
 
-network: "ethereum_geth" # Selected network for test execution
-keep_environments: Never # Options: Always, OnFail, Never
+network: "ethereum_hardhat" # Selected network for test execution
+keep_environments: OnFail # Options: Always, OnFail, Never
 
 apps:
     chainlink:

--- a/contracts/contract_deployer.go
+++ b/contracts/contract_deployer.go
@@ -160,7 +160,7 @@ func DefaultOffChainAggregatorConfig(numberNodes int) OffChainAggregatorConfig {
 		F:                int(math.Max(1, float64(numberNodes/3-1))),
 		OracleIdentities: []ocrConfigHelper.OracleIdentityExtra{},
 	}
-} // VM Exception while processing transaction: revert faulty-oracle threshold too high
+}
 
 // DeployOffChainAggregator deploys the offchain aggregation contract to the EVM chain
 func (e *EthereumContractDeployer) DeployOffChainAggregator(

--- a/contracts/contract_models.go
+++ b/contracts/contract_models.go
@@ -40,7 +40,7 @@ type SetOraclesOptions struct {
 
 type FluxAggregator interface {
 	Address() string
-	Fund(fromWallet client.BlockchainWallet, ethAmount *big.Int, linkAmount *big.Int) error
+	Fund(fromWallet client.BlockchainWallet, ethAmount, linkAmount *big.Float) error
 	AwaitNextRoundFinalized(ctx context.Context) error
 	LatestRound(ctx context.Context) (*big.Int, error)
 	GetContractData(ctxt context.Context) (*FluxAggregatorData, error)
@@ -58,7 +58,7 @@ type FluxAggregator interface {
 type LinkToken interface {
 	Address() string
 	BalanceOf(ctx context.Context, addr common.Address) (*big.Int, error)
-	Fund(fromWallet client.BlockchainWallet, ethAmount *big.Int) error
+	Fund(fromWallet client.BlockchainWallet, ethAmount *big.Float) error
 	Name(context.Context) (string, error)
 }
 
@@ -98,7 +98,7 @@ type OffchainAggregatorData struct {
 
 type OffchainAggregator interface {
 	Address() string
-	Fund(client.BlockchainWallet, *big.Int, *big.Int) error
+	Fund(fromWallet client.BlockchainWallet, nativeAmount, linkAmount *big.Float) error
 	GetContractData(ctxt context.Context) (*OffchainAggregatorData, error)
 	SetConfig(
 		fromWallet client.BlockchainWallet,
@@ -114,13 +114,13 @@ type OffchainAggregator interface {
 
 type Oracle interface {
 	Address() string
-	Fund(fromWallet client.BlockchainWallet, ethAmount *big.Int, linkAmount *big.Int) error
+	Fund(fromWallet client.BlockchainWallet, ethAmount, linkAmount *big.Float) error
 	SetFulfillmentPermission(fromWallet client.BlockchainWallet, address string, allowed bool) error
 }
 
 type APIConsumer interface {
 	Address() string
-	Fund(fromWallet client.BlockchainWallet, ethAmount *big.Int, linkAmount *big.Int) error
+	Fund(fromWallet client.BlockchainWallet, ethAmount, linkAmount *big.Float) error
 	Data(ctx context.Context) (*big.Int, error)
 	CreateRequestTo(
 		fromWallet client.BlockchainWallet,
@@ -139,7 +139,7 @@ type Storage interface {
 }
 
 type VRF interface {
-	Fund(client.BlockchainWallet, *big.Int, *big.Int) error
+	Fund(fromWallet client.BlockchainWallet, ethAmount, linkAmount *big.Float) error
 	ProofLength(context.Context) (*big.Int, error)
 }
 

--- a/contracts/ethereum_contracts.go
+++ b/contracts/ethereum_contracts.go
@@ -28,7 +28,7 @@ func (e *EthereumOracle) Address() string {
 	return e.address.Hex()
 }
 
-func (e *EthereumOracle) Fund(fromWallet client.BlockchainWallet, ethAmount *big.Int, linkAmount *big.Int) error {
+func (e *EthereumOracle) Fund(fromWallet client.BlockchainWallet, ethAmount, linkAmount *big.Float) error {
 	return e.client.Fund(fromWallet, e.address.Hex(), ethAmount, linkAmount)
 }
 
@@ -60,7 +60,7 @@ func (e *EthereumAPIConsumer) Address() string {
 	return e.address.Hex()
 }
 
-func (e *EthereumAPIConsumer) Fund(fromWallet client.BlockchainWallet, ethAmount *big.Int, linkAmount *big.Int) error {
+func (e *EthereumAPIConsumer) Fund(fromWallet client.BlockchainWallet, ethAmount, linkAmount *big.Float) error {
 	return e.client.Fund(fromWallet, e.address.Hex(), ethAmount, linkAmount)
 }
 
@@ -114,7 +114,7 @@ func (f *EthereumFluxAggregator) Address() string {
 }
 
 // Fund sends specified currencies to the contract
-func (f *EthereumFluxAggregator) Fund(fromWallet client.BlockchainWallet, ethAmount, linkAmount *big.Int) error {
+func (f *EthereumFluxAggregator) Fund(fromWallet client.BlockchainWallet, ethAmount, linkAmount *big.Float) error {
 	return f.client.Fund(fromWallet, f.address.Hex(), ethAmount, linkAmount)
 }
 
@@ -327,7 +327,7 @@ type EthereumLinkToken struct {
 }
 
 // Fund the LINK Token contract with ETH to distribute the token
-func (l *EthereumLinkToken) Fund(fromWallet client.BlockchainWallet, ethAmount *big.Int) error {
+func (l *EthereumLinkToken) Fund(fromWallet client.BlockchainWallet, ethAmount *big.Float) error {
 	return l.client.Fund(fromWallet, l.address.Hex(), ethAmount, nil)
 }
 
@@ -367,7 +367,7 @@ type EthereumOffchainAggregator struct {
 }
 
 // Fund sends specified currencies to the contract
-func (o *EthereumOffchainAggregator) Fund(fromWallet client.BlockchainWallet, ethAmount, linkAmount *big.Int) error {
+func (o *EthereumOffchainAggregator) Fund(fromWallet client.BlockchainWallet, ethAmount, linkAmount *big.Float) error {
 	return o.client.Fund(fromWallet, o.address.Hex(), ethAmount, linkAmount)
 }
 
@@ -604,7 +604,7 @@ type EthereumVRF struct {
 }
 
 // Fund sends specified currencies to the contract
-func (v *EthereumVRF) Fund(fromWallet client.BlockchainWallet, ethAmount, linkAmount *big.Int) error {
+func (v *EthereumVRF) Fund(fromWallet client.BlockchainWallet, ethAmount, linkAmount *big.Float) error {
 	return v.client.Fund(fromWallet, v.address.Hex(), ethAmount, linkAmount)
 }
 

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -2,9 +2,10 @@ package environment
 
 import (
 	"fmt"
-	"github.com/smartcontractkit/integrations-framework/client"
 	"net/http"
 	"net/url"
+
+	"github.com/smartcontractkit/integrations-framework/client"
 )
 
 // Environment is the interface that represents a deployed environment, whether locally or on remote machines
@@ -19,30 +20,31 @@ type Environment interface {
 
 // ServiceDetails contains all of the connectivity properties about a given deployed service
 type ServiceDetails struct {
-	RemoteURL  *url.URL
-	LocalURL   *url.URL
+	RemoteURL *url.URL
+	LocalURL  *url.URL
 }
 
 // GetChainlinkClients will return all instantiated Chainlink clients for a given environment
-func GetChainlinkClients(env Environment) ([]client.Chainlink, []*ServiceDetails, error) {
+func GetChainlinkClients(env Environment) ([]client.Chainlink, error) {
 	var clients []client.Chainlink
 
 	sd, err := env.GetAllServiceDetails(ChainlinkWebPort)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	for _, service := range sd {
 		linkClient, err := client.NewChainlink(&client.ChainlinkConfig{
 			URL:      service.LocalURL.String(),
 			Email:    "notreal@fakeemail.ch",
 			Password: "twochains",
+			RemoteIP: service.RemoteURL.Hostname(),
 		}, http.DefaultClient)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		clients = append(clients, linkClient)
 	}
-	return clients, sd, nil
+	return clients, nil
 }
 
 // ExternalAdapter represents a dummy external adapter within the k8sEnvironment

--- a/environment/k8s_environment_test.go
+++ b/environment/k8s_environment_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Environment functionality", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 		defer env.TearDown()
 
-		clients, _, err := GetChainlinkClients(env)
+		clients, err := GetChainlinkClients(env)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(len(clients)).Should(Equal(nodeCount))
 

--- a/environment/k8s_environment_test.go
+++ b/environment/k8s_environment_test.go
@@ -44,6 +44,6 @@ var _ = Describe("Environment functionality", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 	},
 		Entry("1 node cluster", client.NewNetworkFromConfig, NewChainlinkCluster(1), 1),
-		Entry("5 node cluster", client.NewNetworkFromConfig, NewChainlinkCluster(5), 5),
+		Entry("3 node cluster", client.NewNetworkFromConfig, NewChainlinkCluster(3), 3),
 	)
 })

--- a/suite/contracts/contracts_cron_test.go
+++ b/suite/contracts/contracts_cron_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Cronjob suite", func() {
 				client.NewNetworkFromConfig,
 			)
 			Expect(err).ShouldNot(HaveOccurred())
-			nodes, _, err = environment.GetChainlinkClients(s.Env)
+			nodes, err = environment.GetChainlinkClients(s.Env)
 			Expect(err).ShouldNot(HaveOccurred())
 			adapter, err = environment.GetExternalAdapter(s.Env)
 			Expect(err).ShouldNot(HaveOccurred())

--- a/suite/contracts/contracts_flux_test.go
+++ b/suite/contracts/contracts_flux_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Flux monitor suite", func() {
 		By("Deploying and funding contract", func() {
 			fluxInstance, err = s.Deployer.DeployFluxAggregatorContract(s.Wallets.Default(), contracts.DefaultFluxAggregatorOptions())
 			Expect(err).ShouldNot(HaveOccurred())
-			err = fluxInstance.Fund(s.Wallets.Default(), big.NewInt(0), big.NewInt(1e18))
+			err = fluxInstance.Fund(s.Wallets.Default(), nil, big.NewFloat(1))
 			Expect(err).ShouldNot(HaveOccurred())
 			err = fluxInstance.UpdateAvailableFunds(context.Background(), s.Wallets.Default())
 			Expect(err).ShouldNot(HaveOccurred())
@@ -54,7 +54,7 @@ var _ = Describe("Flux monitor suite", func() {
 				nodes,
 				s.Client,
 				s.Wallets.Default(),
-				big.NewInt(2e18),
+				big.NewFloat(2),
 				nil,
 			)
 			Expect(err).ShouldNot(HaveOccurred())

--- a/suite/contracts/contracts_flux_test.go
+++ b/suite/contracts/contracts_flux_test.go
@@ -2,10 +2,11 @@ package contracts
 
 import (
 	"context"
-	"github.com/smartcontractkit/integrations-framework/actions"
 	"math/big"
 	"strings"
 	"time"
+
+	"github.com/smartcontractkit/integrations-framework/actions"
 
 	"github.com/ethereum/go-ethereum/common"
 	. "github.com/onsi/ginkgo"
@@ -33,7 +34,7 @@ var _ = Describe("Flux monitor suite", func() {
 				client.NewNetworkFromConfig,
 			)
 			Expect(err).ShouldNot(HaveOccurred())
-			nodes, _, err = environment.GetChainlinkClients(s.Env)
+			nodes, err = environment.GetChainlinkClients(s.Env)
 			Expect(err).ShouldNot(HaveOccurred())
 			adapter, err = environment.GetExternalAdapter(s.Env)
 			Expect(err).ShouldNot(HaveOccurred())

--- a/suite/contracts/contracts_ocr_test.go
+++ b/suite/contracts/contracts_ocr_test.go
@@ -46,8 +46,8 @@ var _ = FDescribe("OCR Feed", func() {
 				chainlinkNodes,
 				suiteSetup.Client,
 				defaultWallet,
-				big.NewInt(2^18),
-				big.NewInt(2^18),
+				big.NewFloat(2),
+				big.NewFloat(2),
 			)
 			Expect(err).ShouldNot(HaveOccurred())
 
@@ -63,7 +63,7 @@ var _ = FDescribe("OCR Feed", func() {
 				contracts.DefaultOffChainAggregatorConfig(len(chainlinkNodes)),
 			)
 			Expect(err).ShouldNot(HaveOccurred())
-			err = ocrInstance.Fund(defaultWallet, big.NewInt(0), big.NewInt(2^18))
+			err = ocrInstance.Fund(defaultWallet, nil, big.NewFloat(2))
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
@@ -110,7 +110,7 @@ var _ = FDescribe("OCR Feed", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Wait for a round
-			for i := 0; i < 100; i++ {
+			for i := 0; i < 10000; i++ {
 				round, err := ocrInstance.GetLatestRound(context.Background())
 				Expect(err).ShouldNot(HaveOccurred())
 				log.Info().

--- a/suite/contracts/contracts_ocr_test.go
+++ b/suite/contracts/contracts_ocr_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/smartcontractkit/integrations-framework/environment"
 )
 
-var _ = FDescribe("OCR Feed", func() {
+var _ = Describe("OCR Feed", func() {
 	var (
 		suiteSetup     *actions.DefaultSuiteSetup
 		chainlinkNodes []client.Chainlink

--- a/suite/contracts/contracts_ocr_test.go
+++ b/suite/contracts/contracts_ocr_test.go
@@ -110,7 +110,7 @@ var _ = FDescribe("OCR Feed", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Wait for a round
-			for i := 0; i < 10000; i++ {
+			for i := 0; i < 10; i++ {
 				round, err := ocrInstance.GetLatestRound(context.Background())
 				Expect(err).ShouldNot(HaveOccurred())
 				log.Info().

--- a/suite/contracts/contracts_ocr_test.go
+++ b/suite/contracts/contracts_ocr_test.go
@@ -1,0 +1,141 @@
+package contracts
+
+import (
+	"context"
+	"math/big"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/rs/zerolog/log"
+	"github.com/smartcontractkit/integrations-framework/actions"
+	"github.com/smartcontractkit/integrations-framework/client"
+	"github.com/smartcontractkit/integrations-framework/contracts"
+	"github.com/smartcontractkit/integrations-framework/environment"
+)
+
+var _ = FDescribe("OCR Feed", func() {
+	var (
+		suiteSetup     *actions.DefaultSuiteSetup
+		chainlinkNodes []client.Chainlink
+		adapter        environment.ExternalAdapter
+		defaultWallet  client.BlockchainWallet
+	)
+
+	BeforeEach(func() {
+		By("Deploying the environment", func() {
+			var err error
+			suiteSetup, err = actions.DefaultLocalSetup(
+				environment.NewChainlinkCluster(5),
+				client.NewNetworkFromConfig,
+			)
+			Expect(err).ShouldNot(HaveOccurred())
+			adapter, err = environment.GetExternalAdapter(suiteSetup.Env)
+			Expect(err).ShouldNot(HaveOccurred())
+			chainlinkNodes, err = environment.GetChainlinkClients(suiteSetup.Env)
+			Expect(err).ShouldNot(HaveOccurred())
+			defaultWallet = suiteSetup.Wallets.Default()
+		})
+	})
+
+	It("Deploys an OCR feed", func() {
+		var ocrInstance contracts.OffchainAggregator
+
+		By("Funding nodes and deploying OCR contract", func() {
+			err := actions.FundChainlinkNodes(
+				chainlinkNodes,
+				suiteSetup.Client,
+				defaultWallet,
+				big.NewInt(2^18),
+				big.NewInt(2^18),
+			)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Deploy and config OCR contract
+			deployer, err := contracts.NewContractDeployer(suiteSetup.Client)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			ocrInstance, err = deployer.DeployOffChainAggregator(defaultWallet, contracts.DefaultOffChainAggregatorOptions())
+			Expect(err).ShouldNot(HaveOccurred())
+			err = ocrInstance.SetConfig(
+				defaultWallet,
+				chainlinkNodes,
+				contracts.DefaultOffChainAggregatorConfig(len(chainlinkNodes)),
+			)
+			Expect(err).ShouldNot(HaveOccurred())
+			err = ocrInstance.Fund(defaultWallet, big.NewInt(0), big.NewInt(2^18))
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		By("Sending OCR jobs to chainlink nodes", func() {
+			// Initialize bootstrap node
+			bootstrapNode := chainlinkNodes[0]
+			bootstrapP2PIds, err := bootstrapNode.ReadP2PKeys()
+			Expect(err).ShouldNot(HaveOccurred())
+			bootstrapP2PId := bootstrapP2PIds.Data[0].Attributes.PeerID
+			bootstrapSpec := &client.OCRBootstrapJobSpec{
+				ContractAddress: ocrInstance.Address(),
+				P2PPeerID:       bootstrapP2PId,
+				IsBootstrapPeer: true,
+			}
+			_, err = bootstrapNode.CreateJob(bootstrapSpec)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Send OCR job to other nodes
+			for index := 1; index < len(chainlinkNodes); index++ {
+				nodeP2PIds, err := chainlinkNodes[index].ReadP2PKeys()
+				Expect(err).ShouldNot(HaveOccurred())
+				nodeP2PId := nodeP2PIds.Data[0].Attributes.PeerID
+				nodeTransmitterAddress, err := chainlinkNodes[index].PrimaryEthAddress()
+				Expect(err).ShouldNot(HaveOccurred())
+				nodeOCRKeys, err := chainlinkNodes[index].ReadOCRKeys()
+				Expect(err).ShouldNot(HaveOccurred())
+				nodeOCRKeyId := nodeOCRKeys.Data[0].ID
+
+				ocrSpec := &client.OCRTaskJobSpec{
+					ContractAddress:    ocrInstance.Address(),
+					P2PPeerID:          nodeP2PId,
+					P2PBootstrapPeers:  []client.Chainlink{bootstrapNode},
+					KeyBundleID:        nodeOCRKeyId,
+					TransmitterAddress: nodeTransmitterAddress,
+					ObservationSource:  client.ObservationSourceSpec(adapter.ClusterURL() + "/five"),
+				}
+				_, err = chainlinkNodes[index].CreateJob(ocrSpec)
+				Expect(err).ShouldNot(HaveOccurred())
+			}
+		})
+
+		By("Checking OCR rounds", func() {
+			err := ocrInstance.RequestNewRound(defaultWallet)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Wait for a round
+			for i := 0; i < 100; i++ {
+				round, err := ocrInstance.GetLatestRound(context.Background())
+				Expect(err).ShouldNot(HaveOccurred())
+				log.Info().
+					Str("Contract Address", ocrInstance.Address()).
+					Str("Answer", round.Answer.String()).
+					Str("Round ID", round.RoundId.String()).
+					Str("Answered in Round", round.AnsweredInRound.String()).
+					Str("Started At", round.StartedAt.String()).
+					Str("Updated At", round.UpdatedAt.String()).
+					Msg("Latest Round Data")
+				if round.RoundId.Cmp(big.NewInt(0)) > 0 {
+					break // Break when OCR round processes
+				}
+				time.Sleep(time.Second)
+			}
+
+			// Check answer is as expected
+			answer, err := ocrInstance.GetLatestAnswer(context.Background())
+			log.Info().Str("Answer", answer.String()).Msg("Final Answer")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(answer.Int64()).Should(Equal(int64(5)))
+		})
+	})
+
+	AfterEach(func() {
+		By("Tearing down the environment", suiteSetup.TearDown())
+	})
+})

--- a/suite/contracts/contracts_runlog_test.go
+++ b/suite/contracts/contracts_runlog_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Direct request suite", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			nodeAddresses, err = actions.ChainlinkNodeAddresses(nodes)
 			Expect(err).ShouldNot(HaveOccurred())
-			err = actions.FundChainlinkNodes(nodes, s.Client, s.Wallets.Default(), big.NewInt(2e18), nil)
+			err = actions.FundChainlinkNodes(nodes, s.Client, s.Wallets.Default(), big.NewFloat(2), nil)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 		By("Deploying and funding the contracts", func() {
@@ -53,7 +53,7 @@ var _ = Describe("Direct request suite", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			consumer, err = s.Deployer.DeployAPIConsumer(s.Wallets.Default(), s.Link.Address())
 			Expect(err).ShouldNot(HaveOccurred())
-			err = consumer.Fund(s.Wallets.Default(), nil, big.NewInt(2e18))
+			err = consumer.Fund(s.Wallets.Default(), nil, big.NewFloat(2))
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 		By("Permitting node to fulfill request", func() {

--- a/suite/contracts/contracts_runlog_test.go
+++ b/suite/contracts/contracts_runlog_test.go
@@ -3,6 +3,9 @@ package contracts
 import (
 	"context"
 	"errors"
+	"math/big"
+	"strings"
+
 	"github.com/avast/retry-go"
 	"github.com/ethereum/go-ethereum/common"
 	. "github.com/onsi/ginkgo"
@@ -13,8 +16,6 @@ import (
 	"github.com/smartcontractkit/integrations-framework/client"
 	"github.com/smartcontractkit/integrations-framework/contracts"
 	"github.com/smartcontractkit/integrations-framework/environment"
-	"math/big"
-	"strings"
 )
 
 var _ = Describe("Direct request suite", func() {
@@ -40,7 +41,7 @@ var _ = Describe("Direct request suite", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 		By("Funding Chainlink nodes", func() {
-			nodes, _, err = environment.GetChainlinkClients(s.Env)
+			nodes, err = environment.GetChainlinkClients(s.Env)
 			Expect(err).ShouldNot(HaveOccurred())
 			nodeAddresses, err = actions.ChainlinkNodeAddresses(nodes)
 			Expect(err).ShouldNot(HaveOccurred())

--- a/suite/contracts/contracts_test.go
+++ b/suite/contracts/contracts_test.go
@@ -3,236 +3,79 @@ package contracts
 import (
 	"context"
 	"math/big"
-	"time"
 
 	"github.com/smartcontractkit/integrations-framework/actions"
-
-	"github.com/smartcontractkit/integrations-framework/config"
 	"github.com/smartcontractkit/integrations-framework/contracts"
 	"github.com/smartcontractkit/integrations-framework/environment"
 
-	"github.com/rs/zerolog/log"
 	"github.com/smartcontractkit/integrations-framework/client"
 
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("OCR Feed", func() {
-	var conf *config.Config
+var _ = Describe("Basic Contract Interactions", func() {
+	var suiteSetup *actions.DefaultSuiteSetup
+	var defaultWallet client.BlockchainWallet
 
 	BeforeEach(func() {
-		var err error
-		conf, err = config.NewConfig(config.LocalConfig)
-		Expect(err).ShouldNot(HaveOccurred())
+		By("Deploying the environment", func() {
+			var err error
+			suiteSetup, err = actions.DefaultLocalSetup(
+				environment.NewChainlinkCluster(0),
+				client.NewNetworkFromConfig,
+			)
+			Expect(err).ShouldNot(HaveOccurred())
+			defaultWallet = suiteSetup.Wallets.Default()
+		})
 	})
 
-	DescribeTable("deploy and use basic functionality", func(
-		initFunc client.BlockchainNetworkInit,
-		ocrOptions contracts.OffchainOptions,
-	) {
-		// Setup
-		network, err := initFunc(conf)
-		Expect(err).ShouldNot(HaveOccurred())
-		env, err := environment.NewK8sEnvironment(environment.NewChainlinkCluster(7), conf, network)
-		Expect(err).ShouldNot(HaveOccurred())
-		defer env.TearDown()
-
-		chainlinkNodes, _, err := environment.GetChainlinkClients(env)
-		Expect(err).ShouldNot(HaveOccurred())
-		blockchain, err := environment.NewBlockchainClient(env, network)
-		Expect(err).ShouldNot(HaveOccurred())
-		wallets, err := network.Wallets()
-		Expect(err).ShouldNot(HaveOccurred())
-		adapter, err := environment.GetExternalAdapter(env)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Fund each chainlink node
-		err = actions.FundChainlinkNodes(
-			chainlinkNodes,
-			blockchain,
-			wallets.Default(),
-			big.NewInt(2^18),
-			big.NewInt(2^18),
-		)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Deploy and config OCR contract
-		deployer, err := contracts.NewContractDeployer(blockchain)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		ocrInstance, err := deployer.DeployOffChainAggregator(wallets.Default(), ocrOptions)
-		Expect(err).ShouldNot(HaveOccurred())
-		err = ocrInstance.SetConfig(
-			wallets.Default(),
-			chainlinkNodes,
-			contracts.DefaultOffChainAggregatorConfig(len(chainlinkNodes)),
-		)
-		Expect(err).ShouldNot(HaveOccurred())
-		err = ocrInstance.Fund(wallets.Default(), big.NewInt(2^18), big.NewInt(2^18))
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Initialize bootstrap node
-		bootstrapNode := chainlinkNodes[0]
-		bootstrapP2PIds, err := bootstrapNode.ReadP2PKeys()
-		Expect(err).ShouldNot(HaveOccurred())
-		bootstrapP2PId := bootstrapP2PIds.Data[0].Attributes.PeerID
-		bootstrapSpec := &client.OCRBootstrapJobSpec{
-			ContractAddress: ocrInstance.Address(),
-			P2PPeerID:       bootstrapP2PId,
-			IsBootstrapPeer: true,
-		}
-		_, err = bootstrapNode.CreateJob(bootstrapSpec)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Send OCR job to other nodes
-		for index := 1; index < len(chainlinkNodes); index++ {
-			nodeP2PIds, err := chainlinkNodes[index].ReadP2PKeys()
+	It("exercises basic contract usage", func() {
+		By("deploying the storage contract", func() {
+			// Deploy storage
+			storeInstance, err := suiteSetup.Deployer.DeployStorageContract(defaultWallet)
 			Expect(err).ShouldNot(HaveOccurred())
-			nodeP2PId := nodeP2PIds.Data[0].Attributes.PeerID
-			nodeTransmitterAddress, err := chainlinkNodes[index].PrimaryEthAddress()
-			Expect(err).ShouldNot(HaveOccurred())
-			nodeOCRKeys, err := chainlinkNodes[index].ReadOCRKeys()
-			Expect(err).ShouldNot(HaveOccurred())
-			nodeOCRKeyId := nodeOCRKeys.Data[0].ID
 
-			ocrSpec := &client.OCRTaskJobSpec{
-				ContractAddress:    ocrInstance.Address(),
-				P2PPeerID:          nodeP2PId,
-				P2PBootstrapPeers:  []string{bootstrapP2PId},
-				KeyBundleID:        nodeOCRKeyId,
-				TransmitterAddress: nodeTransmitterAddress,
-				ObservationSource:  client.ObservationSourceSpec(adapter.ClusterURL() + "/five"),
-			}
-			_, err = chainlinkNodes[index].CreateJob(ocrSpec)
+			testVal := big.NewInt(5)
+
+			// Interact with contract
+			err = storeInstance.Set(testVal)
 			Expect(err).ShouldNot(HaveOccurred())
-		}
-
-		// Request a new round from the OCR
-		err = ocrInstance.RequestNewRound(wallets.Default())
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Wait for a round
-		for i := 0; i < 30; i++ {
-			round, err := ocrInstance.GetLatestRound(context.Background())
+			val, err := storeInstance.Get(context.Background())
 			Expect(err).ShouldNot(HaveOccurred())
-			log.Info().
-				Str("Contract Address", ocrInstance.Address()).
-				Str("Answer", round.Answer.String()).
-				Str("Round ID", round.RoundId.String()).
-				Str("Answered in Round", round.AnsweredInRound.String()).
-				Str("Started At", round.StartedAt.String()).
-				Str("Updated At", round.UpdatedAt.String()).
-				Msg("Latest Round Data")
-			if round.RoundId.Cmp(big.NewInt(0)) > 0 {
-				break // Break when OCR round processes
-			}
-			time.Sleep(time.Second)
-		}
+			Expect(val).To(Equal(testVal))
+		})
 
-		// Check answer is as expected
-		answer, err := ocrInstance.GetLatestAnswer(context.Background())
-		log.Info().Str("Answer", answer.String()).Msg("Final Answer")
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(answer.Int64()).Should(Equal(int64(5)))
-	},
-		Entry("on Ethereum Hardhat", client.NewNetworkFromConfig, contracts.DefaultOffChainAggregatorOptions()),
-	)
+		By("deploying the flux monitor contract", func() {
+			// Deploy FluxMonitor contract
+			fluxOptions := contracts.DefaultFluxAggregatorOptions()
+			fluxInstance, err := suiteSetup.Deployer.DeployFluxAggregatorContract(defaultWallet, fluxOptions)
+			Expect(err).ShouldNot(HaveOccurred())
+			err = fluxInstance.Fund(defaultWallet, big.NewInt(0), big.NewInt(50000000000))
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Interact with contract
+			desc, err := fluxInstance.Description(context.Background())
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(desc).To(Equal(fluxOptions.Description))
+		})
+
+		By("deploying the ocr contract", func() {
+			// Deploy Offchain contract
+			ocrOptions := contracts.DefaultOffChainAggregatorOptions()
+			offChainInstance, err := suiteSetup.Deployer.DeployOffChainAggregator(defaultWallet, ocrOptions)
+			Expect(err).ShouldNot(HaveOccurred())
+			err = offChainInstance.Fund(defaultWallet, nil, big.NewInt(50000000000))
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Check a round
+			ans, err := offChainInstance.GetLatestAnswer(context.Background())
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(ans).ShouldNot(Equal(nil))
+		})
+	})
+
+	AfterEach(func() {
+		By("Tearing down the environment", suiteSetup.TearDown())
+	})
 })
-
-// var _ = Describe("Contracts", func() {
-// 	var conf *config.Config
-
-// 	BeforeEach(func() {
-// 		var err error
-// 		conf, err = config.NewWithPath(config.LocalConfig, "../../config")
-// 		Expect(err).ShouldNot(HaveOccurred())
-// 	})
-
-// 	DescribeTable("deploy and interact with the storage contract", func(
-// 		initFunc client.BlockchainNetworkInit,
-// 		value *big.Int,
-// 	) {
-// 		network, err := initFunc(conf)
-// 		Expect(err).ShouldNot(HaveOccurred())
-// 		testEnv, err := environment.NewK8sEnvironment("storage-contract", 0, network)
-// 		Expect(err).ShouldNot(HaveOccurred())
-
-// 		storeInstance, err := testEnv.ContractDeployer().DeployStorageContract(testEnv.Wallets().Default())
-// 		Expect(err).ShouldNot(HaveOccurred())
-
-// 		// Interact with contract
-// 		err = storeInstance.Set(value)
-// 		Expect(err).ShouldNot(HaveOccurred())
-// 		val, err := storeInstance.Get(context.Background())
-// 		Expect(err).ShouldNot(HaveOccurred())
-// 		Expect(val).To(Equal(value))
-
-// 		err = testEnv.TearDown()
-// 		Expect(err).ShouldNot(HaveOccurred())
-// 	},
-// 		Entry("on Ethereum Hardhat", client.NewNetworkFromConfig, big.NewInt(5)),
-// 	)
-
-// 	DescribeTable("deploy and interact with the FluxAggregator contract", func(
-// 		initFunc client.BlockchainNetworkInit,
-// 		fluxOptions contracts.FluxAggregatorOptions,
-// 	) {
-// 		network, err := initFunc(conf)
-// 		Expect(err).ShouldNot(HaveOccurred())
-// 		testEnv, err := environment.NewK8sEnvironment("flux-aggregator-contract", 0, network)
-// 		Expect(err).ShouldNot(HaveOccurred())
-
-// 		// Deploy LINK contract
-// 		linkInstance, err := testEnv.ContractDeployer().DeployLinkTokenContract(testEnv.Wallets().Default())
-// 		Expect(err).ShouldNot(HaveOccurred())
-// 		name, err := linkInstance.Name(context.Background())
-// 		Expect(err).ShouldNot(HaveOccurred())
-// 		Expect(name).To(Equal("ChainLink Token"))
-
-// 		// Deploy FluxMonitor contract
-// 		fluxInstance, err := testEnv.ContractDeployer().DeployFluxAggregatorContract(testEnv.Wallets().Default(), fluxOptions)
-// 		Expect(err).ShouldNot(HaveOccurred())
-// 		err = fluxInstance.Fund(testEnv.Wallets().Default(), big.NewInt(0), big.NewInt(50000000000))
-// 		Expect(err).ShouldNot(HaveOccurred())
-
-// 		// Interact with contract
-// 		desc, err := fluxInstance.Description(context.Background())
-// 		Expect(err).ShouldNot(HaveOccurred())
-// 		Expect(desc).To(Equal(fluxOptions.Description))
-
-// 		err = testEnv.TearDown()
-// 		Expect(err).ShouldNot(HaveOccurred())
-// 	},
-// 		Entry("on Ethereum Hardhat", client.NewNetworkFromConfig, contracts.DefaultFluxAggregatorOptions()),
-// 	)
-
-// 	DescribeTable("deploy and interact with the OffChain Aggregator contract", func(
-// 		initFunc client.BlockchainNetworkInit,
-// 		ocrOptions contracts.OffchainOptions,
-// 	) {
-// 		network, err := initFunc(conf)
-// 		Expect(err).ShouldNot(HaveOccurred())
-// 		testEnv, err := environment.NewK8sEnvironment("ocr-contract", 0, network)
-// 		Expect(err).ShouldNot(HaveOccurred())
-
-// 		// Deploy LINK contract
-// 		linkInstance, err := testEnv.ContractDeployer().DeployLinkTokenContract(testEnv.Wallets().Default())
-// 		Expect(err).ShouldNot(HaveOccurred())
-// 		name, err := linkInstance.Name(context.Background())
-// 		Expect(err).ShouldNot(HaveOccurred())
-// 		Expect(name).To(Equal("ChainLink Token"))
-
-// 		// Deploy Offchain contract
-// 		offChainInstance, err := testEnv.ContractDeployer().DeployOffChainAggregator(testEnv.Wallets().Default(), ocrOptions)
-// 		Expect(err).ShouldNot(HaveOccurred())
-// 		err = offChainInstance.Fund(testEnv.Wallets().Default(), nil, big.NewInt(50000000000))
-// 		Expect(err).ShouldNot(HaveOccurred())
-
-// 		err = testEnv.TearDown()
-// 		Expect(err).ShouldNot(HaveOccurred())
-// 	},
-// 		Entry("on Ethereum Hardhat", client.NewNetworkFromConfig, contracts.DefaultOffChainAggregatorOptions()),
-// 	)
-// })

--- a/suite/contracts/contracts_test.go
+++ b/suite/contracts/contracts_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Basic Contract Interactions", func() {
 			fluxOptions := contracts.DefaultFluxAggregatorOptions()
 			fluxInstance, err := suiteSetup.Deployer.DeployFluxAggregatorContract(defaultWallet, fluxOptions)
 			Expect(err).ShouldNot(HaveOccurred())
-			err = fluxInstance.Fund(defaultWallet, big.NewInt(0), big.NewInt(50000000000))
+			err = fluxInstance.Fund(defaultWallet, nil, big.NewFloat(.005))
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Interact with contract
@@ -65,7 +65,7 @@ var _ = Describe("Basic Contract Interactions", func() {
 			ocrOptions := contracts.DefaultOffChainAggregatorOptions()
 			offChainInstance, err := suiteSetup.Deployer.DeployOffChainAggregator(defaultWallet, ocrOptions)
 			Expect(err).ShouldNot(HaveOccurred())
-			err = offChainInstance.Fund(defaultWallet, nil, big.NewInt(50000000000))
+			err = offChainInstance.Fund(defaultWallet, nil, big.NewFloat(.005))
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Check a round

--- a/suite/refill/eth_refill_test.go
+++ b/suite/refill/eth_refill_test.go
@@ -35,7 +35,7 @@ var _ = Describe("FluxAggregator ETH Refill", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			adapter, err = environment.GetExternalAdapter(s.Env)
 			Expect(err).ShouldNot(HaveOccurred())
-			nodes, _, err = environment.GetChainlinkClients(s.Env)
+			nodes, err = environment.GetChainlinkClients(s.Env)
 			Expect(err).ShouldNot(HaveOccurred())
 			nodeAddresses, err = actions.ChainlinkNodeAddresses(nodes)
 			Expect(err).ShouldNot(HaveOccurred())

--- a/suite/refill/eth_refill_test.go
+++ b/suite/refill/eth_refill_test.go
@@ -49,7 +49,7 @@ var _ = Describe("FluxAggregator ETH Refill", func() {
 				contracts.DefaultFluxAggregatorOptions(),
 			)
 			Expect(err).ShouldNot(HaveOccurred())
-			err = fluxInstance.Fund(s.Wallets.Default(), big.NewInt(0), big.NewInt(1e18))
+			err = fluxInstance.Fund(s.Wallets.Default(), nil, big.NewFloat(1))
 			Expect(err).ShouldNot(HaveOccurred())
 			err = fluxInstance.UpdateAvailableFunds(context.Background(), s.Wallets.Default())
 			Expect(err).ShouldNot(HaveOccurred())
@@ -94,7 +94,7 @@ var _ = Describe("FluxAggregator ETH Refill", func() {
 		})
 
 		By("Funding ETH for a single round", func() {
-			err = actions.FundChainlinkNodes(nodes, s.Client, s.Wallets.Default(), big.NewInt(1e16), nil)
+			err = actions.FundChainlinkNodes(nodes, s.Client, s.Wallets.Default(), big.NewFloat(1), nil)
 			Expect(err).ShouldNot(HaveOccurred())
 			err = adapter.SetVariable(6)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -112,7 +112,7 @@ var _ = Describe("FluxAggregator ETH Refill", func() {
 
 	Describe("with FluxAggregator", func() {
 		It("should refill and await the next round", func() {
-			err = actions.FundChainlinkNodes(nodes, s.Client, s.Wallets.Default(), big.NewInt(2e18), nil)
+			err = actions.FundChainlinkNodes(nodes, s.Client, s.Wallets.Default(), big.NewFloat(2), nil)
 			Expect(err).ShouldNot(HaveOccurred())
 			err = fluxInstance.AwaitNextRoundFinalized(context.Background())
 			Expect(err).ShouldNot(HaveOccurred())

--- a/suite/refill/eth_refill_test.go
+++ b/suite/refill/eth_refill_test.go
@@ -94,7 +94,7 @@ var _ = Describe("FluxAggregator ETH Refill", func() {
 		})
 
 		By("Funding ETH for a single round", func() {
-			err = actions.FundChainlinkNodes(nodes, s.Client, s.Wallets.Default(), big.NewFloat(1), nil)
+			err = actions.FundChainlinkNodes(nodes, s.Client, s.Wallets.Default(), big.NewFloat(.01), nil)
 			Expect(err).ShouldNot(HaveOccurred())
 			err = adapter.SetVariable(6)
 			Expect(err).ShouldNot(HaveOccurred())


### PR DESCRIPTION
# OCR Test Fixes

Fixes for OCR testing to work properly

## Building off Jonny's `ServiceDetails` Work

Simplifying what Jonny did for the `ServiceDetails` stuff so that P2P works. Didn't need quite all of the info all the time though. Just needed the remoteIP for the chainlink nodes to hang on to. This allows you to just pass in an array of `ChainlinkNode`s for configuration purposes, looks much cleaner.

```go
// GetChainlinkClients will return all instantiated Chainlink clients for a given environment
func GetChainlinkClients(env Environment) ([]client.Chainlink, error) {
	var clients []client.Chainlink

	sd, err := env.GetAllServiceDetails(ChainlinkWebPort)
	if err != nil {
		return nil, err
	}
	for _, service := range sd {
		linkClient, err := client.NewChainlink(&client.ChainlinkConfig{
			URL:      service.LocalURL.String(),
			Email:    "notreal@fakeemail.ch",
			Password: "twochains",
			RemoteIP: service.RemoteURL.Hostname(),
		}, http.DefaultClient)
		if err != nil {
			return nil, err
		}
		clients = append(clients, linkClient)
	}
	return clients, nil
}
```

## Changing How We Get Our Funding

```go
nativeAmount, linkAmount *big.Float
```

Funding was full of integer overflows due to confusion around how much we were sending. I've put in a new proposal where token values are listed, e.g.
```go
var OneLINK = big.NewFloat(1000000000000000000)
...
var OneEth = big.NewFloat(1000000000000000000)
```

And when calling to fund a contract or node, you simply give a multiple of one of that currency. e.g.
```go
err := actions.FundChainlinkNodes(
  chainlinkNodes,
  suiteSetup.Client,
  defaultWallet,
  big.NewFloat(2),
  big.NewFloat(2), // Fund each node with 2 ETH and 2 LINK each
)
...
err = fluxInstance.Fund(defaultWallet, nil, big.NewFloat(.005)) // Fund flux monitor contract with .005 ETH
```