### PR TITLE
Grabs logs from environment pods on test failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ artifacts/
 
 # JUnit Test Reports
 junit.xml
+
+logs/

--- a/actions/setup.go
+++ b/actions/setup.go
@@ -1,10 +1,11 @@
 package actions
 
 import (
-	"github.com/onsi/ginkgo"
-	"github.com/rs/zerolog/log"
 	"strings"
 	"time"
+
+	"github.com/onsi/ginkgo"
+	"github.com/rs/zerolog/log"
 
 	"github.com/avast/retry-go"
 	"github.com/smartcontractkit/integrations-framework/client"

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -15,6 +15,7 @@ type Environment interface {
 	GetAllServiceDetails(remotePort uint16) ([]*ServiceDetails, error)
 	GetServiceDetails(remotePort uint16) (*ServiceDetails, error)
 
+	WriteLogs(testLogFolder string)
 	TearDown()
 }
 

--- a/environment/k8s_environment.go
+++ b/environment/k8s_environment.go
@@ -211,12 +211,11 @@ func (env *k8sEnvironment) logFailures() {
 		if err != nil {
 			log.Err(err).Str("File Name", logFile.Name()).Msg("Error creating log file")
 		}
-		defer logFile.Close()
 
-		logFile.WriteString("======================================================================================\n")
-		logFile.WriteString("Test file name: " + ginkgo.CurrentGinkgoTestDescription().FileName + "\n")
-		logFile.WriteString("Test file line: " + fmt.Sprint(ginkgo.CurrentGinkgoTestDescription().LineNumber) + "\n")
-		logFile.WriteString("======================================================================================\n")
+		_, _ = logFile.WriteString("======================================================================================\n")
+		_, _ = logFile.WriteString("Test file name: " + ginkgo.CurrentGinkgoTestDescription().FileName + "\n")
+		_, _ = logFile.WriteString("Test file line: " + fmt.Sprint(ginkgo.CurrentGinkgoTestDescription().LineNumber) + "\n")
+		_, _ = logFile.WriteString("======================================================================================\n")
 
 		podLogOptions := &coreV1.PodLogOptions{}
 		if strings.Contains(podName, "chainlink") {
@@ -228,7 +227,6 @@ func (env *k8sEnvironment) logFailures() {
 		if err != nil {
 			log.Err(err).Str("Env Name", env.namespace.Name).Msg("error in opening pod logging stream")
 		}
-		defer podLogs.Close()
 
 		buf := new(bytes.Buffer)
 		_, err = io.Copy(buf, podLogs)
@@ -236,6 +234,9 @@ func (env *k8sEnvironment) logFailures() {
 			log.Err(err).Str("Env Name", env.namespace.Name).Msg("error in copying information from podLogs to a buffer")
 		}
 		logFile.Write(buf.Bytes())
+
+		_ = logFile.Close()
+		_ = podLogs.Close()
 	}
 }
 

--- a/environment/k8s_environment.go
+++ b/environment/k8s_environment.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/avast/retry-go"
 	"github.com/hashicorp/go-multierror"
-	"github.com/onsi/ginkgo"
 	"github.com/smartcontractkit/integrations-framework/config"
 	"gopkg.in/yaml.v2"
 
@@ -206,11 +205,6 @@ func writeLogsForPod(podsClient v1.PodInterface, pod coreV1.Pod, podFolder strin
 		if err != nil {
 			log.Err(err).Str("File Name", logFile.Name()).Msg("Error creating log file")
 		}
-
-		_, _ = logFile.WriteString("======================================================================================\n")
-		_, _ = logFile.WriteString("Test file name: " + ginkgo.CurrentGinkgoTestDescription().FileName + "\n")
-		_, _ = logFile.WriteString("Test file line: " + fmt.Sprint(ginkgo.CurrentGinkgoTestDescription().LineNumber) + "\n")
-		_, _ = logFile.WriteString("======================================================================================\n")
 
 		podLogRequest := podsClient.GetLogs(pod.Name, &coreV1.PodLogOptions{Container: container.Name})
 		podLogs, err := podLogRequest.Stream(context.Background())

--- a/environment/k8s_environment.go
+++ b/environment/k8s_environment.go
@@ -217,10 +217,17 @@ func writeLogsForPod(podsClient v1.PodInterface, pod coreV1.Pod, podFolder strin
 		if err != nil {
 			return err
 		}
-		_, _ = logFile.Write(buf.Bytes())
+		_, err = logFile.Write(buf.Bytes())
+		if err != nil {
+			return err
+		}
 
-		_ = logFile.Close()
-		_ = podLogs.Close()
+		if err = logFile.Close(); err != nil {
+			return err
+		}
+		if err = podLogs.Close(); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/environment/k8s_environment.go
+++ b/environment/k8s_environment.go
@@ -233,7 +233,7 @@ func (env *k8sEnvironment) logFailures() {
 		if err != nil {
 			log.Err(err).Str("Env Name", env.namespace.Name).Msg("error in copying information from podLogs to a buffer")
 		}
-		logFile.Write(buf.Bytes())
+		_, _ = logFile.Write(buf.Bytes())
 
 		_ = logFile.Close()
 		_ = podLogs.Close()

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/rs/zerolog v1.21.0
 	github.com/satori/go.uuid v1.2.0
 	github.com/smartcontractkit/libocr v0.0.0-20210604141828-45d17f043949
-	github.com/spf13/cobra v1.1.1 // indirect
+	github.com/spf13/cobra v1.1.1
 	github.com/spf13/viper v1.8.0
 	golang.org/x/crypto v0.0.0-20210506145944-38f3c27a63bf // indirect
 	gopkg.in/yaml.v2 v2.4.0

--- a/suite/refill/eth_refill_test.go
+++ b/suite/refill/eth_refill_test.go
@@ -16,6 +16,37 @@ import (
 	"github.com/smartcontractkit/integrations-framework/environment"
 )
 
+var _ = FDescribe("TODO", func() {
+	var (
+		suiteSetup *actions.DefaultSuiteSetup
+		err        error
+	)
+
+	BeforeEach(func() {
+		suiteSetup, err = actions.DefaultLocalSetup(
+			environment.NewChainlinkCluster(2),
+			client.NewNetworkFromConfig,
+		)
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+
+	It("should fail", func() {
+		By("being wrong", func() {
+			Expect(1).Should(Equal(2))
+		})
+	})
+
+	It("should also fail", func() {
+		By("being wrong", func() {
+			Expect(1).Should(Equal(2))
+		})
+	})
+
+	AfterEach(func() {
+		By("tearing down", suiteSetup.TearDown())
+	})
+})
+
 var _ = Describe("FluxAggregator ETH Refill", func() {
 	var (
 		s             *actions.DefaultSuiteSetup

--- a/suite/refill/eth_refill_test.go
+++ b/suite/refill/eth_refill_test.go
@@ -16,37 +16,6 @@ import (
 	"github.com/smartcontractkit/integrations-framework/environment"
 )
 
-var _ = FDescribe("TODO", func() {
-	var (
-		suiteSetup *actions.DefaultSuiteSetup
-		err        error
-	)
-
-	BeforeEach(func() {
-		suiteSetup, err = actions.DefaultLocalSetup(
-			environment.NewChainlinkCluster(2),
-			client.NewNetworkFromConfig,
-		)
-		Expect(err).ShouldNot(HaveOccurred())
-	})
-
-	It("should fail", func() {
-		By("being wrong", func() {
-			Expect(1).Should(Equal(2))
-		})
-	})
-
-	It("should also fail", func() {
-		By("being wrong", func() {
-			Expect(1).Should(Equal(2))
-		})
-	})
-
-	AfterEach(func() {
-		By("tearing down", suiteSetup.TearDown())
-	})
-})
-
 var _ = Describe("FluxAggregator ETH Refill", func() {
 	var (
 		s             *actions.DefaultSuiteSetup


### PR DESCRIPTION
# Grabbing Logs on Test Failure
On a test failure, creates a log folder for that test, then creates files for each pod and dumps logs into them.
<img width="269" alt="logs_image" src="https://user-images.githubusercontent.com/10038988/128392299-ce956285-b627-4839-863a-dbedcaa3781d.png">

