### PR TITLE
Support for parallel transactions

### DIFF
--- a/actions/actions.go
+++ b/actions/actions.go
@@ -1,9 +1,9 @@
 package actions
 
 import (
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
 	"github.com/satori/go.uuid"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/smartcontractkit/integrations-framework/client"
 	"math/big"
 	"strings"
@@ -27,7 +27,7 @@ func FundChainlinkNodes(
 			return err
 		}
 	}
-	return nil
+	return blockchain.WaitForTransactions()
 }
 
 // ChainlinkNodeAddresses will return all the on-chain wallet addresses for a set of Chainlink nodes

--- a/actions/setup.go
+++ b/actions/setup.go
@@ -102,6 +102,12 @@ func (s *DefaultSuiteSetup) TearDown() func() {
 		log.Info().Str("Log Folder", testLogFolder).Msg("Wrote environment logs")
 	}
 	return func() {
+		if err := s.Client.Close(); err != nil {
+			log.Error().
+				Str("Network", s.Config.Network).
+				Msgf("Error while closing the Blockchain client: %v", err)
+		}
+
 		switch strings.ToLower(s.Config.KeepEnvironments) {
 		case KeepEnvironmentsNever:
 			s.Env.TearDown()

--- a/client/blockchain.go
+++ b/client/blockchain.go
@@ -20,6 +20,9 @@ const BlockchainTypeEVM = "evm"
 type BlockchainClient interface {
 	Get() interface{}
 	Fund(fromWallet BlockchainWallet, toAddress string, nativeAmount, linkAmount *big.Float) error
+	ParallelTransactions(enabled bool)
+	WaitForTransactions() error
+	Close() error
 }
 
 // NewBlockchainClient returns an instantiated network client implementation based on the network configuration given

--- a/client/ethereum.go
+++ b/client/ethereum.go
@@ -474,7 +474,7 @@ func (t *TransactionConfirmer) Wait() error {
 			t.cancel()
 			return nil
 		case <-t.context.Done():
-			return t.context.Err()
+			return fmt.Errorf("timeout waiting for transaction to confirm: %s", t.txHash.String())
 		}
 	}
 }

--- a/config.yml
+++ b/config.yml
@@ -91,7 +91,9 @@ retry:
     attempts: 20
     linear_delay: 1s
 
-# Increase k8s default throttling variables to avoid test slowdown
 kubernetes:
+    # Increase k8s default throttling variables to avoid test slowdown
     qps: 50
     burst: 50
+    # How long to wait for the environment to deploy & be marked as healthy before test errors
+    deployment_timeout: 3m

--- a/config.yml
+++ b/config.yml
@@ -45,6 +45,7 @@ networks:
         transaction_timeout: 10s
         minimum_confirmations: 1
         gas_estimation_buffer: 0
+        block_gas_limit: 40000000
     ethereum_hardhat:
         name: "Ethereum Hardhat"
         chain_id: 1337
@@ -58,31 +59,12 @@ networks:
         name: "Ethereum Ganache"
         chain_id: 1337
         type: evm
-        private_keys:
-            - 4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d
-            - 6cbed15c793ce57650b9877cf6fa156fbef513c4e6134f022a85b1ffdd59b2a1
-            - 6370fd033278c143179d81c5526140625662b8daa446c22ee2d73db3707e620c
-            - 646f1ce2fdad0e6deeeb5c7e8e5543bdde65e86029e2fd9fc169899c440a7913
-            - add53f9a7e588d003326d1cbf9e4a43c061aadd9bc938c843a79e7b4fd2ad743
-            - 395df67f0c2d2d9fe1ad08d1bc8b6627011959b79c53d7dd6a3536a33ab8a4fd
-            - e485d098507f54e7733a205420dfddbe58db035fa577fc294ebd14db90767a52
-            - a453611d9419d0e56f499079478fd72c37b251a94bfde4d19872c44cf65386e3
-            - 829e924fdf021ba3dbbc4225edfece9aca04b929d6e75613329ca6f1d31c0bb4
-            - b0057716d5917badaf911b193b12b910811c1497b5bada8d7711f758981c3773
-            - 77c5495fbb039eed474fc940f29955ed0531693cc9212911efd35dff0373153f
-            - d99b5b29e6da2528bf458b26237a6cf8655a3e3276c1cdc0de1f98cefee81c01
-            - 9b9c613a36396172eab2d34d72331c8ca83a358781883a535d2941f66db07b24
-            - 0874049f95d55fb76916262dc70571701b5c4cc5900c0691af75f1a8a52c8268
-            - 21d7212f3b4e5332fd465877b64926e3532653e2798a11255a46f533852dfe46
-            - 47b65307d0d654fd4f786b908c04af8fface7710fc998b37d219de19c39ee58c
-            - 66109972a14d82dbdb6894e61f74708f26128814b3359b64f8b66565679f7299
-            - 2eac15546def97adc6d69ca6e28eec831189baa2533e7910755d15403a0749e8
-            - 2e114163041d2fb8d45f9251db259a68ee6bdbfd6d10fe1ae87c5c4bcd6ba491
-            - ae9a2e131e9b359b198fa280de53ddbe2247730b881faae7af08e567e58915bd    
+        <<: *private_keys
         transaction_limit: 9500000
         transaction_timeout: 1s
         minimum_confirmations: 0
         gas_estimation_buffer: 0
+        block_gas_limit: 40000000
     ethereum_kovan:
         name: "Ethereum Kovan"
         url: "wss://127.0.0.1:8545"

--- a/config.yml
+++ b/config.yml
@@ -54,6 +54,35 @@ networks:
         transaction_timeout: 1s
         minimum_confirmations: 1
         gas_estimation_buffer: 0
+    ethereum_ganache:
+        name: "Ethereum Ganache"
+        chain_id: 1337
+        type: evm
+        private_keys:
+            - 4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d
+            - 6cbed15c793ce57650b9877cf6fa156fbef513c4e6134f022a85b1ffdd59b2a1
+            - 6370fd033278c143179d81c5526140625662b8daa446c22ee2d73db3707e620c
+            - 646f1ce2fdad0e6deeeb5c7e8e5543bdde65e86029e2fd9fc169899c440a7913
+            - add53f9a7e588d003326d1cbf9e4a43c061aadd9bc938c843a79e7b4fd2ad743
+            - 395df67f0c2d2d9fe1ad08d1bc8b6627011959b79c53d7dd6a3536a33ab8a4fd
+            - e485d098507f54e7733a205420dfddbe58db035fa577fc294ebd14db90767a52
+            - a453611d9419d0e56f499079478fd72c37b251a94bfde4d19872c44cf65386e3
+            - 829e924fdf021ba3dbbc4225edfece9aca04b929d6e75613329ca6f1d31c0bb4
+            - b0057716d5917badaf911b193b12b910811c1497b5bada8d7711f758981c3773
+            - 77c5495fbb039eed474fc940f29955ed0531693cc9212911efd35dff0373153f
+            - d99b5b29e6da2528bf458b26237a6cf8655a3e3276c1cdc0de1f98cefee81c01
+            - 9b9c613a36396172eab2d34d72331c8ca83a358781883a535d2941f66db07b24
+            - 0874049f95d55fb76916262dc70571701b5c4cc5900c0691af75f1a8a52c8268
+            - 21d7212f3b4e5332fd465877b64926e3532653e2798a11255a46f533852dfe46
+            - 47b65307d0d654fd4f786b908c04af8fface7710fc998b37d219de19c39ee58c
+            - 66109972a14d82dbdb6894e61f74708f26128814b3359b64f8b66565679f7299
+            - 2eac15546def97adc6d69ca6e28eec831189baa2533e7910755d15403a0749e8
+            - 2e114163041d2fb8d45f9251db259a68ee6bdbfd6d10fe1ae87c5c4bcd6ba491
+            - ae9a2e131e9b359b198fa280de53ddbe2247730b881faae7af08e567e58915bd    
+        transaction_limit: 9500000
+        transaction_timeout: 1s
+        minimum_confirmations: 0
+        gas_estimation_buffer: 0
     ethereum_kovan:
         name: "Ethereum Kovan"
         url: "wss://127.0.0.1:8545"

--- a/config.yml
+++ b/config.yml
@@ -42,7 +42,7 @@ networks:
         type: evm
         <<: *private_keys
         transaction_limit: 9500000
-        transaction_timeout: 2s
+        transaction_timeout: 10s
         minimum_confirmations: 1
         gas_estimation_buffer: 0
     ethereum_hardhat:

--- a/config/config.go
+++ b/config/config.go
@@ -55,8 +55,9 @@ type NetworkConfig struct {
 
 // KubernetesConfig holds the configuration for how the framework interacts with the k8s cluster
 type KubernetesConfig struct {
-	QPS   float32 `mapstructure:"qps" yaml:"qps"`
-	Burst int     `mapstructure:"burst" yaml:"burst"`
+	QPS               float32       `mapstructure:"qps" yaml:"qps"`
+	Burst             int           `mapstructure:"burst" yaml:"burst"`
+	DeploymentTimeout time.Duration `mapstructure:"deployment_timeout" yaml:"deployment_timeout"`
 }
 
 // AppConfig holds all the configuration for the core apps that are deployed for testing

--- a/config/config.go
+++ b/config/config.go
@@ -49,6 +49,7 @@ type NetworkConfig struct {
 	LinkTokenAddress     string        `mapstructure:"link_token_address" yaml:"link_token_address"`
 	MinimumConfirmations int           `mapstructure:"minimum_confirmations" yaml:"minimum_confirmations"`
 	GasEstimationBuffer  uint64        `mapstructure:"gas_estimation_buffer" yaml:"gas_estimation_buffer"`
+	BlockGasLimit        uint64        `mapstructure:"block_gas_limit" yaml:"block_gas_limit"`
 	PrivateKeyStore      PrivateKeyStore
 }
 

--- a/contracts/ethereum_contracts.go
+++ b/contracts/ethereum_contracts.go
@@ -44,10 +44,7 @@ func (e *EthereumOracle) SetFulfillmentPermission(fromWallet client.BlockchainWa
 	if err != nil {
 		return err
 	}
-	if err := e.client.WaitForTransaction(tx.Hash()); err != nil {
-		return err
-	}
-	return nil
+	return e.client.ProcessTransaction(tx.Hash())
 }
 
 // EthereumAPIConsumer API consumer for job type "directrequest" tests
@@ -97,10 +94,7 @@ func (e *EthereumAPIConsumer) CreateRequestTo(
 	if err != nil {
 		return err
 	}
-	if err := e.client.WaitForTransaction(tx.Hash()); err != nil {
-		return err
-	}
-	return nil
+	return e.client.ProcessTransaction(tx.Hash())
 }
 
 // EthereumFluxAggregator represents the basic flux aggregation contract
@@ -129,10 +123,7 @@ func (f *EthereumFluxAggregator) UpdateAvailableFunds(ctx context.Context, fromW
 	if err != nil {
 		return err
 	}
-	if err := f.client.WaitForTransaction(tx.Hash()); err != nil {
-		return err
-	}
-	return nil
+	return f.client.ProcessTransaction(tx.Hash())
 }
 
 func (f *EthereumFluxAggregator) PaymentAmount(ctx context.Context) (*big.Int, error) {
@@ -157,10 +148,7 @@ func (f *EthereumFluxAggregator) RequestNewRound(ctx context.Context, fromWallet
 	if err != nil {
 		return err
 	}
-	if err := f.client.WaitForTransaction(tx.Hash()); err != nil {
-		return err
-	}
-	return nil
+	return f.client.ProcessTransaction(tx.Hash())
 }
 
 func (f *EthereumFluxAggregator) SetRequesterPermissions(ctx context.Context, fromWallet client.BlockchainWallet, addr common.Address, authorized bool, roundsDelay uint32) error {
@@ -172,7 +160,7 @@ func (f *EthereumFluxAggregator) SetRequesterPermissions(ctx context.Context, fr
 	if err != nil {
 		return err
 	}
-	return f.client.WaitForTransaction(tx.Hash())
+	return f.client.ProcessTransaction(tx.Hash())
 }
 
 func (f *EthereumFluxAggregator) GetOracles(ctx context.Context) ([]string, error) {
@@ -211,7 +199,7 @@ func (f *EthereumFluxAggregator) AwaitNextRoundFinalized(ctx context.Context) er
 	if err != nil {
 		return err
 	}
-	log.Info().Int64("round", lr.Int64()).Msg("awaiting next round after")
+	log.Info().Int64("Round", lr.Int64()).Msg("Awaiting next round after")
 	if err := retry.Do(func() error {
 		newRound, err := f.LatestRound(ctx)
 		if err != nil {
@@ -241,7 +229,7 @@ func (f *EthereumFluxAggregator) WithdrawPayment(
 	if err != nil {
 		return err
 	}
-	return f.client.WaitForTransaction(tx.Hash())
+	return f.client.ProcessTransaction(tx.Hash())
 }
 
 func (f *EthereumFluxAggregator) WithdrawablePayment(ctx context.Context, addr common.Address) (*big.Int, error) {
@@ -307,7 +295,7 @@ func (f *EthereumFluxAggregator) SetOracles(
 	if err != nil {
 		return err
 	}
-	return f.client.WaitForTransaction(tx.Hash())
+	return f.client.ProcessTransaction(tx.Hash())
 }
 
 // Description returns the description of the flux aggregator contract
@@ -369,7 +357,7 @@ func (l *EthereumLinkToken) Approve(fromWallet client.BlockchainWallet, to strin
 	if err != nil {
 		return err
 	}
-	return l.client.WaitForTransaction(tx.Hash())
+	return l.client.ProcessTransaction(tx.Hash())
 }
 
 func (l *EthereumLinkToken) Transfer(fromWallet client.BlockchainWallet, to string, amount *big.Int) error {
@@ -381,7 +369,7 @@ func (l *EthereumLinkToken) Transfer(fromWallet client.BlockchainWallet, to stri
 	if err != nil {
 		return err
 	}
-	return l.client.WaitForTransaction(tx.Hash())
+	return l.client.ProcessTransaction(tx.Hash())
 }
 
 func (l *EthereumLinkToken) TransferAndCall(fromWallet client.BlockchainWallet, to string, amount *big.Int, data []byte) error {
@@ -393,7 +381,7 @@ func (l *EthereumLinkToken) TransferAndCall(fromWallet client.BlockchainWallet, 
 	if err != nil {
 		return err
 	}
-	return l.client.WaitForTransaction(tx.Hash())
+	return l.client.ProcessTransaction(tx.Hash())
 }
 
 // EthereumOffchainAggregator represents the offchain aggregation contract
@@ -442,7 +430,7 @@ func (o *EthereumOffchainAggregator) SetPayees(
 	if err != nil {
 		return err
 	}
-	return o.client.WaitForTransaction(tx.Hash())
+	return o.client.ProcessTransaction(tx.Hash())
 }
 
 // SetConfig sets offchain reporting protocol configuration including participating oracles
@@ -525,8 +513,7 @@ func (o *EthereumOffchainAggregator) SetConfig(
 	if err != nil {
 		return err
 	}
-	err = o.client.WaitForTransaction(tx.Hash())
-	if err != nil {
+	if err := o.client.ProcessTransaction(tx.Hash()); err != nil {
 		return err
 	}
 
@@ -539,7 +526,7 @@ func (o *EthereumOffchainAggregator) SetConfig(
 	if err != nil {
 		return err
 	}
-	return o.client.WaitForTransaction(tx.Hash())
+	return o.client.ProcessTransaction(tx.Hash())
 }
 
 // RequestNewRound requests the OCR contract to create a new round
@@ -553,7 +540,8 @@ func (o *EthereumOffchainAggregator) RequestNewRound(fromWallet client.Blockchai
 		return err
 	}
 	log.Info().Str("Contract Address", o.address.Hex()).Msg("New OCR round requested")
-	return o.client.WaitForTransaction(tx.Hash())
+
+	return o.client.ProcessTransaction(tx.Hash())
 }
 
 // Link returns the LINK contract address on the EVM chain
@@ -620,7 +608,7 @@ func (e *EthereumStorage) Set(value *big.Int) error {
 	if err != nil {
 		return err
 	}
-	return e.client.WaitForTransaction(transaction.Hash())
+	return e.client.ProcessTransaction(transaction.Hash())
 }
 
 // Get retrieves a set value from the storage contract
@@ -705,7 +693,7 @@ func (v *EthereumKeeperRegistry) SetRegistrar(fromWallet client.BlockchainWallet
 	if err != nil {
 		return err
 	}
-	return v.client.WaitForTransaction(tx.Hash())
+	return v.client.ProcessTransaction(tx.Hash())
 }
 
 // AddUpkeepFunds adds link for particular upkeep id
@@ -718,7 +706,7 @@ func (v *EthereumKeeperRegistry) AddUpkeepFunds(fromWallet client.BlockchainWall
 	if err != nil {
 		return err
 	}
-	if err := v.client.WaitForTransaction(tx.Hash()); err != nil {
+	if err := v.client.ProcessTransaction(tx.Hash()); err != nil {
 		return err
 	}
 	return nil
@@ -780,7 +768,7 @@ func (v *EthereumKeeperRegistry) SetKeepers(fromWallet client.BlockchainWallet, 
 	if err != nil {
 		return err
 	}
-	if err := v.client.WaitForTransaction(tx.Hash()); err != nil {
+	if err := v.client.ProcessTransaction(tx.Hash()); err != nil {
 		return err
 	}
 	return nil
@@ -796,7 +784,7 @@ func (v *EthereumKeeperRegistry) RegisterUpkeep(fromWallet client.BlockchainWall
 	if err != nil {
 		return err
 	}
-	if err := v.client.WaitForTransaction(tx.Hash()); err != nil {
+	if err := v.client.ProcessTransaction(tx.Hash()); err != nil {
 		return err
 	}
 	return nil
@@ -878,7 +866,7 @@ func (v *EthereumUpkeepRegistrationRequests) SetRegistrarConfig(
 	if err != nil {
 		return err
 	}
-	return v.client.WaitForTransaction(tx.Hash())
+	return v.client.ProcessTransaction(tx.Hash())
 }
 
 func (v *EthereumUpkeepRegistrationRequests) Fund(fromWallet client.BlockchainWallet, ethAmount, linkAmount *big.Float) error {
@@ -969,10 +957,7 @@ func (v *EthereumVRFCoordinator) RegisterProvingKey(
 	if err != nil {
 		return err
 	}
-	if err := v.client.WaitForTransaction(tx.Hash()); err != nil {
-		return err
-	}
-	return nil
+	return v.client.ProcessTransaction(tx.Hash())
 }
 
 // EthereumVRFConsumer represents VRF consumer contract
@@ -1000,10 +985,7 @@ func (v *EthereumVRFConsumer) RequestRandomness(fromWallet client.BlockchainWall
 	if err != nil {
 		return err
 	}
-	if err := v.client.WaitForTransaction(tx.Hash()); err != nil {
-		return err
-	}
-	return nil
+	return v.client.ProcessTransaction(tx.Hash())
 }
 
 func (v *EthereumVRFConsumer) RandomnessOutput(ctx context.Context) (*big.Int, error) {

--- a/environment/k8s_environment.go
+++ b/environment/k8s_environment.go
@@ -113,8 +113,24 @@ func NewK8sEnvironment(
 	env.namespace = namespace
 	env.specs = deployables
 
-	if err := env.deploySpecs(); err != nil {
-		return nil, err
+	ctx, ctxCancel := context.WithTimeout(context.Background(), env.config.Kubernetes.DeploymentTimeout)
+	defer ctxCancel()
+
+	errChan := make(chan error)
+	go env.deploySpecs(errChan)
+
+deploymentLoop:
+	for {
+		select {
+		case err, open := <-errChan:
+			if err != nil {
+				return nil, err
+			} else if !open {
+				break deploymentLoop
+			}
+		case <-ctx.Done():
+			return nil, fmt.Errorf("error while waiting for deployment: %v", ctx.Err())
+		}
 	}
 	return env, err
 }
@@ -159,7 +175,7 @@ func (env *k8sEnvironment) GetServiceDetails(remotePort uint16) (*ServiceDetails
 	}
 }
 
-// On a test failure, dump all the pod logs
+// WriteLogs dumps all the pod logs on test failure
 func (env *k8sEnvironment) WriteLogs(testLogFolder string) {
 	// Get logs from K8s pods
 	podsClient := env.k8sClient.CoreV1().Pods(env.namespace.Name)
@@ -232,12 +248,13 @@ func writeLogsForPod(podsClient v1.PodInterface, pod coreV1.Pod, podFolder strin
 	return nil
 }
 
-func (env *k8sEnvironment) deploySpecs() error {
+func (env *k8sEnvironment) deploySpecs(errChan chan<- error) {
 	values := map[string]interface{}{}
 	for i := 0; i < len(env.specs); i++ {
 		spec, ok := env.specs[i]
 		if !ok {
-			return fmt.Errorf("specifcation %d wasn't found on deploy, make sure the set are in order", i)
+			errChan <- fmt.Errorf("specifcation %d wasn't found on deploy, make sure the set are in order", i)
+			return
 		}
 		if err := spec.SetEnvironment(
 			env.k8sClient,
@@ -246,18 +263,21 @@ func (env *k8sEnvironment) deploySpecs() error {
 			env.network.Config(),
 			env.namespace,
 		); err != nil {
-			return err
+			errChan <- err
+			return
 		}
 		values[spec.ID()] = spec.Values()
 		if err := spec.Deploy(values); err != nil {
-			return err
+			errChan <- err
+			return
 		}
 		if err := spec.WaitUntilHealthy(); err != nil {
-			return err
+			errChan <- err
+			return
 		}
 		values[spec.ID()] = spec.Values()
 	}
-	return nil
+	close(errChan)
 }
 
 func (env *k8sEnvironment) createNamespace(namespace string) (*coreV1.Namespace, error) {

--- a/environment/templates/ganache-deployment.yml
+++ b/environment/templates/ganache-deployment.yml
@@ -12,14 +12,30 @@ spec:
         ports:
         - containerport: {{ .Values.evm.rpcPort }}
         args:
-          - -d
-          - myth like bonus scare over problem client lizard pioneer submit female collect
-          - -a
-          - 20
-          - -i
-          - 1337
-          - -l
-          - 10000000
+          - --account "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80,100000000000000000000"
+          - --account "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d,100000000000000000000"
+          - --account "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a,100000000000000000000"
+          - --account "0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6,100000000000000000000"
+          - --account "0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a,100000000000000000000"
+          - --account "0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba,100000000000000000000"
+          - --account "0x92db14e403b83dfe3df233f83dfa3a0d7096f21ca9b0d6d6b8d88b2b4ec1564e,100000000000000000000"
+          - --account "0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356,100000000000000000000"
+          - --account "0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97,100000000000000000000"
+          - --account "0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6,100000000000000000000"
+          - --account "0xf214f2b2cd398c806f84e317254e0f0b801d0643303237d97a22a48e01628897,100000000000000000000"
+          - --account "0x701b615bbdfb9de65240bc28bd21bbc0d996645a3dd57e7b12bc2bdf6f192c82,100000000000000000000"
+          - --account "0xa267530f49f8280200edf313ee7af6b827f2a8bce2897751d06a843f644967b1,100000000000000000000"
+          - --account "0x47c99abed3324a2707c28affff1267e45918ec8c3f20b8aa892e8b065d2942dd,100000000000000000000"
+          - --account "0xc526ee95bf44d8fc405a158bb884d9d1238d99f0612e9f33d006bb0789009aaa,100000000000000000000"
+          - --account "0x8166f546bab6da521a8369cab06c5d2b9e46670292d85c875ee9ec20e84ffb61,100000000000000000000"
+          - --account "0xea6c44ac03bff858b476bba40716402b03e41b8e97e276d1baec7c37d42484a0,100000000000000000000"
+          - --account "0x689af8efa8c651a91ad287602527f3af2fe9f6501a7ac4b061667b5a93e037fd,100000000000000000000"
+          - --account "0xde9be858da4a475276426320d5e9262ecfc3ba460bfac56360bfa6c4c28b4ee0,100000000000000000000"
+          - --account "0xdf57089febbacf7ba0bc227dafbffa9fc08a93fdc68e1e42411a14efcf23656e,100000000000000000000"
+          - --hostname '0.0.0.0'
+          - --networkId '{{ .Network.ChainID }}'
+          - --deterministic
+          - --gasLimit '{{ .Network.BlockGasLimit }}'
         readinessProbe:
           tcpSocket:
             port: {{ .Values.evm.rpcPort }}

--- a/environment/templates/ganache-deployment.yml
+++ b/environment/templates/ganache-deployment.yml
@@ -1,0 +1,26 @@
+objectmeta:
+  name: ganache
+spec:
+  template:
+    objectmeta:
+      labels:
+        app: ganache-network
+    spec:
+      containers:
+      - name: ganache-network
+        image: trufflesuite/ganache-cli:v6.12.2
+        ports:
+        - containerport: {{ .Values.evm.rpcPort }}
+        args:
+          - -d
+          - myth like bonus scare over problem client lizard pioneer submit female collect
+          - -a
+          - 20
+          - -i
+          - 1337
+          - -l
+          - 10000000
+        readinessProbe:
+          tcpSocket:
+            port: {{ .Values.evm.rpcPort }}
+          periodSeconds: 2

--- a/environment/templates/ganache-service.yml
+++ b/environment/templates/ganache-service.yml
@@ -1,0 +1,11 @@
+objectmeta:
+  name: ganache-network
+spec:
+  ports:
+  - name: access
+    port: {{ .Values.evm.rpcPort }}
+    targetport:
+      intval: {{ .Values.evm.rpcPort }}
+  selector:
+    app: ganache-network
+  type: ClusterIP

--- a/environment/templates/geth-config-map.yml
+++ b/environment/templates/geth-config-map.yml
@@ -58,7 +58,7 @@ data:
   genesis.json: |
     {
       "config": {
-        "chainId": 1337,
+        "chainId": {{ .Network.ChainID }},
         "homesteadBlock": 0,
         "eip150Block": 0,
         "eip155Block": 0,
@@ -70,7 +70,7 @@ data:
       "coinbase": "0x3333333333333333333333333333333333333333",
       "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
       "extraData": "0x",
-      "gasLimit": "0xE8D4A50FFF",
+      "gasLimit": "{{ .Network.BlockGasLimit }}",
       "alloc": {
         "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266": {
           "balance": "20000000000000000000000"

--- a/environment/templates/geth-deployment.yml
+++ b/environment/templates/geth-deployment.yml
@@ -124,10 +124,12 @@ spec:
           - 0xdD2FD4581271e230360230F9337D5c0430Bf44C0
           - --unlock
           - 0x8626f6940E2eb28930eFb4CeF49B2d1F2C9C1199
-          - --networkid=1337
+          - --networkid={{ .Network.ChainID }}
           - --mine
           - --miner.threads
           - 1
+          - --miner.gastarget
+          - {{ .Network.BlockGasLimit }}
           - --miner.etherbase
           - 0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266
           - --rpcapi="admin,debug,web3,eth,txpool,personal,clique,miner,net"

--- a/suite/contracts/contracts_flux_test.go
+++ b/suite/contracts/contracts_flux_test.go
@@ -38,6 +38,8 @@ var _ = Describe("Flux monitor suite", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			adapter, err = environment.GetExternalAdapter(s.Env)
 			Expect(err).ShouldNot(HaveOccurred())
+
+			s.Client.ParallelTransactions(true)
 		})
 		By("Deploying and funding contract", func() {
 			fluxInstance, err = s.Deployer.DeployFluxAggregatorContract(s.Wallets.Default(), contracts.DefaultFluxAggregatorOptions())
@@ -45,6 +47,8 @@ var _ = Describe("Flux monitor suite", func() {
 			err = fluxInstance.Fund(s.Wallets.Default(), nil, big.NewFloat(1))
 			Expect(err).ShouldNot(HaveOccurred())
 			err = fluxInstance.UpdateAvailableFunds(context.Background(), s.Wallets.Default())
+			Expect(err).ShouldNot(HaveOccurred())
+			err = s.Client.WaitForTransactions()
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 		By("Funding Chainlink nodes", func() {
@@ -69,6 +73,8 @@ var _ = Describe("Flux monitor suite", func() {
 					MaxSubmissions:     3,
 					RestartDelayRounds: 0,
 				})
+			Expect(err).ShouldNot(HaveOccurred())
+			err = s.Client.WaitForTransactions()
 			Expect(err).ShouldNot(HaveOccurred())
 			oracles, err := fluxInstance.GetOracles(context.Background())
 			Expect(err).ShouldNot(HaveOccurred())
@@ -98,7 +104,7 @@ var _ = Describe("Flux monitor suite", func() {
 			{
 				data, err := fluxInstance.GetContractData(context.Background())
 				Expect(err).ShouldNot(HaveOccurred())
-				log.Info().Interface("data", data).Msg("round data")
+				log.Info().Interface("data", data).Msg("Round data")
 				Expect(len(data.Oracles)).Should(Equal(3))
 				Expect(data.LatestRoundData.Answer.Int64()).Should(Equal(int64(5)))
 				Expect(data.LatestRoundData.RoundId.Int64()).Should(Equal(int64(1)))
@@ -120,7 +126,7 @@ var _ = Describe("Flux monitor suite", func() {
 				Expect(data.LatestRoundData.AnsweredInRound.Int64()).Should(Equal(int64(2)))
 				Expect(data.AvailableFunds.Int64()).Should(Equal(int64(999999999999999994)))
 				Expect(data.AllocatedFunds.Int64()).Should(Equal(int64(6)))
-				log.Info().Interface("data", data).Msg("round data")
+				log.Info().Interface("data", data).Msg("Round data")
 			}
 
 			for _, oracleAddr := range nodeAddresses {

--- a/suite/contracts/contracts_ocr_test.go
+++ b/suite/contracts/contracts_ocr_test.go
@@ -35,6 +35,7 @@ var _ = Describe("OCR Feed", func() {
 			chainlinkNodes, err = environment.GetChainlinkClients(suiteSetup.Env)
 			Expect(err).ShouldNot(HaveOccurred())
 			defaultWallet = suiteSetup.Wallets.Default()
+			suiteSetup.Client.ParallelTransactions(true)
 		})
 	})
 
@@ -64,6 +65,8 @@ var _ = Describe("OCR Feed", func() {
 			)
 			Expect(err).ShouldNot(HaveOccurred())
 			err = ocrInstance.Fund(defaultWallet, nil, big.NewFloat(2))
+			Expect(err).ShouldNot(HaveOccurred())
+			err = suiteSetup.Client.WaitForTransactions()
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
@@ -107,6 +110,8 @@ var _ = Describe("OCR Feed", func() {
 
 		By("Checking OCR rounds", func() {
 			err := ocrInstance.RequestNewRound(defaultWallet)
+			Expect(err).ShouldNot(HaveOccurred())
+			err = suiteSetup.Client.WaitForTransactions()
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Wait for a round

--- a/suite/contracts/contracts_vrf_test.go
+++ b/suite/contracts/contracts_vrf_test.go
@@ -56,7 +56,7 @@ var _ = Describe("VRF suite", func() {
 			for _, n := range nodes {
 				nodeKeys, err := n.ReadVRFKeys()
 				Expect(err).ShouldNot(HaveOccurred())
-				log.Debug().Interface("Proving key", nodeKeys).Send()
+				log.Debug().Interface("Key JSON", nodeKeys).Msg("Created proving key")
 				pubKeyCompressed := nodeKeys.Data[0].ID
 				jobUUID := uuid.NewV4()
 				_, err = n.CreateJob(&client.VRFJobSpec{
@@ -99,7 +99,7 @@ var _ = Describe("VRF suite", func() {
 				if out.Uint64() == 0 {
 					return errors.New("randomness has not fulfilled yet")
 				}
-				log.Debug().Uint64("Output", out.Uint64()).Send()
+				log.Debug().Uint64("Output", out.Uint64()).Msg("Randomness fulfilled")
 				return nil
 			})
 			Expect(err).ShouldNot(HaveOccurred())

--- a/suite/refill/eth_refill_test.go
+++ b/suite/refill/eth_refill_test.go
@@ -39,6 +39,8 @@ var _ = Describe("FluxAggregator ETH Refill", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			nodeAddresses, err = actions.ChainlinkNodeAddresses(nodes)
 			Expect(err).ShouldNot(HaveOccurred())
+
+			s.Client.ParallelTransactions(true)
 		})
 	})
 
@@ -53,6 +55,8 @@ var _ = Describe("FluxAggregator ETH Refill", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			err = fluxInstance.UpdateAvailableFunds(context.Background(), s.Wallets.Default())
 			Expect(err).ShouldNot(HaveOccurred())
+			err = s.Client.WaitForTransactions()
+			Expect(err).ShouldNot(HaveOccurred())
 		})
 
 		By("Setting FluxAggregator options", func() {
@@ -64,11 +68,13 @@ var _ = Describe("FluxAggregator ETH Refill", func() {
 					MinSubmissions:     3,
 					MaxSubmissions:     3,
 					RestartDelayRounds: 0,
-				})
+				},
+			)
+			err = s.Client.WaitForTransactions()
 			Expect(err).ShouldNot(HaveOccurred())
 			oracles, err := fluxInstance.GetOracles(context.Background())
 			Expect(err).ShouldNot(HaveOccurred())
-			log.Info().Str("Oracles", strings.Join(oracles, ",")).Msg("oracles set")
+			log.Info().Str("Oracles", strings.Join(oracles, ",")).Msg("Oracles set")
 		})
 
 		By("Adding FluxAggregator jobs to nodes", func() {
@@ -96,6 +102,8 @@ var _ = Describe("FluxAggregator ETH Refill", func() {
 		By("Funding ETH for a single round", func() {
 			err = actions.FundChainlinkNodes(nodes, s.Client, s.Wallets.Default(), big.NewFloat(.01), nil)
 			Expect(err).ShouldNot(HaveOccurred())
+			err = s.Client.WaitForTransactions()
+			Expect(err).ShouldNot(HaveOccurred())
 			err = adapter.SetVariable(6)
 			Expect(err).ShouldNot(HaveOccurred())
 			err = fluxInstance.AwaitNextRoundFinalized(context.Background())
@@ -113,6 +121,8 @@ var _ = Describe("FluxAggregator ETH Refill", func() {
 	Describe("with FluxAggregator", func() {
 		It("should refill and await the next round", func() {
 			err = actions.FundChainlinkNodes(nodes, s.Client, s.Wallets.Default(), big.NewFloat(2), nil)
+			Expect(err).ShouldNot(HaveOccurred())
+			err = s.Client.WaitForTransactions()
 			Expect(err).ShouldNot(HaveOccurred())
 			err = fluxInstance.AwaitNextRoundFinalized(context.Background())
 			Expect(err).ShouldNot(HaveOccurred())


### PR DESCRIPTION
Revamped transaction management in the Ethereum client, also adding new functions to the Blockchain client interface for toggling parallelising transactions, clean shutdowns and a blocking function for waiting for transactions.

By default, parallelisation is disabled. It can be turned on by calling:
```
blockchainClient.ParallelTransactions(true)
```

The Ethereum client will now also only initiate one subscription for block headers with subscription interfaces to receive any block headers, enabling tx confirmations.

This functionality is especially useful for tests with large environments, eg volume tests.

As part of this PR I've added support for Ganache, but it breaks with the Chainlink node with context timeout errors that I haven't fully debugged. PR works fine with Geth dev.