### PR TITLE
Open up the header event subscriptions to the Blockchain interface

### DIFF
--- a/actions/actions.go
+++ b/actions/actions.go
@@ -27,7 +27,7 @@ func FundChainlinkNodes(
 			return err
 		}
 	}
-	return blockchain.WaitForTransactions()
+	return blockchain.WaitForEvents()
 }
 
 // ChainlinkNodeAddresses will return all the on-chain wallet addresses for a set of Chainlink nodes

--- a/client/blockchain.go
+++ b/client/blockchain.go
@@ -4,6 +4,7 @@ package client
 import (
 	"errors"
 	"fmt"
+	"github.com/ethereum/go-ethereum/core/types"
 	"math/big"
 	"strings"
 
@@ -21,8 +22,11 @@ type BlockchainClient interface {
 	Get() interface{}
 	Fund(fromWallet BlockchainWallet, toAddress string, nativeAmount, linkAmount *big.Float) error
 	ParallelTransactions(enabled bool)
-	WaitForTransactions() error
 	Close() error
+
+	AddHeaderEventSubscription(key string, subscriber HeaderEventSubscription)
+	DeleteHeaderEventSubscription(key string)
+	WaitForEvents() error
 }
 
 // NewBlockchainClient returns an instantiated network client implementation based on the network configuration given
@@ -218,4 +222,10 @@ func walletSliceIndexInRange(wallets []BlockchainWallet, i int) error {
 		return fmt.Errorf("invalid index in list of wallets")
 	}
 	return nil
+}
+
+// HeaderEventSubscription is an interface for allowing callbacks when the client receives a new header
+type HeaderEventSubscription interface {
+	ReceiveHeader(header *types.Header) error
+	Wait() error
 }

--- a/client/ethereum.go
+++ b/client/ethereum.go
@@ -77,7 +77,7 @@ func (e *EthereumClient) Get() interface{} {
 }
 
 // ParallelTransactions when enabled, sends the transaction without waiting for transaction confirmations. The hashes
-// are then stored within the client and confirmations can be waited on by calling WaitForTransactions.
+// are then stored within the client and confirmations can be waited on by calling WaitForEvents.
 // When disabled, the minimum confirmations are waited on when the transaction is sent, so parallelisation is disabled.
 func (e *EthereumClient) ParallelTransactions(enabled bool) {
 	e.queueTransactions = enabled
@@ -309,14 +309,14 @@ func (e *EthereumClient) GetHeaderSubscriptions() map[string]HeaderEventSubscrip
 	return newMap
 }
 
-// AddHeaderSubscription adds a new header subscriber within the client to receive new headers
+// AddHeaderEventSubscription adds a new header subscriber within the client to receive new headers
 func (e *EthereumClient) AddHeaderEventSubscription(key string, subscriber HeaderEventSubscription) {
 	e.mutex.Lock()
 	defer e.mutex.Unlock()
 	e.headerSubscriptions[key] = subscriber
 }
 
-// DeleteHeaderSubscription removes a header subscriber from the map
+// DeleteHeaderEventSubscription removes a header subscriber from the map
 func (e *EthereumClient) DeleteHeaderEventSubscription(key string) {
 	e.mutex.Lock()
 	defer e.mutex.Unlock()
@@ -498,3 +498,4 @@ func (i *InstantConfirmations) ReceiveHeader(*types.Header) error {
 func (i *InstantConfirmations) Wait() error {
 	return nil
 }
+

--- a/client/ethereum.go
+++ b/client/ethereum.go
@@ -28,11 +28,11 @@ type EthereumClient struct {
 	Client  *ethclient.Client
 	Network BlockchainNetwork
 
-	txQueue            chan common.Hash
-	queuedTransactions map[string]EthereumTransactionConfirmer
-	mutex              *sync.Mutex
-	queueTransactions  bool
-	doneChan           chan struct{}
+	txQueue             chan common.Hash
+	headerSubscriptions map[string]HeaderEventSubscription
+	mutex               *sync.Mutex
+	queueTransactions   bool
+	doneChan            chan struct{}
 }
 
 // ContractDeployer acts as a go-between function for general contract deployment
@@ -51,13 +51,13 @@ func NewEthereumClient(network BlockchainNetwork) (*EthereumClient, error) {
 	}
 
 	ec := &EthereumClient{
-		Network:            network,
-		Client:             cl,
-		txQueue:            make(chan common.Hash, 64), // Max buffer of 64 tx
-		queuedTransactions: map[string]EthereumTransactionConfirmer{},
-		mutex:              &sync.Mutex{},
-		queueTransactions:  false,
-		doneChan:           make(chan struct{}),
+		Network:             network,
+		Client:              cl,
+		txQueue:             make(chan common.Hash, 64), // Max buffer of 64 tx
+		headerSubscriptions: map[string]HeaderEventSubscription{},
+		mutex:               &sync.Mutex{},
+		queueTransactions:   false,
+		doneChan:            make(chan struct{}),
 	}
 	go ec.newHeadersLoop()
 	return ec, err
@@ -173,20 +173,20 @@ func (e *EthereumClient) SendTransaction(
 
 // ProcessTransaction will queue or wait on a transaction depending on whether queue transactions is enabled
 func (e *EthereumClient) ProcessTransaction(txHash common.Hash) error {
-	var txConfirmer EthereumTransactionConfirmer
+	var txConfirmer HeaderEventSubscription
 	if e.Network.Config().MinimumConfirmations == 0 {
 		txConfirmer = &InstantConfirmations{}
 	} else {
 		txConfirmer = NewTransactionConfirmer(e, txHash, e.Network.Config().MinimumConfirmations)
 	}
 
-	e.AddQueuedTransaction(txHash.String(), txConfirmer)
+	e.AddHeaderEventSubscription(txHash.String(), txConfirmer)
 
 	if !e.queueTransactions {
 		if err := txConfirmer.Wait(); err != nil {
 			return err
 		}
-		e.DeleteQueuedTransaction(txHash.String())
+		e.DeleteHeaderEventSubscription(txHash.String())
 	}
 	return nil
 }
@@ -273,11 +273,11 @@ func (e *EthereumClient) TransactionOpts(
 	return opts, nil
 }
 
-// WaitForTransactions is a blocking function that waits for all transactions that have been queued within the client.
-func (e *EthereumClient) WaitForTransactions() error {
+// WaitForEvents is a blocking function that waits for all event subscriptions that have been queued within the client.
+func (e *EthereumClient) WaitForEvents() error {
 	var errGroup error
 
-	queuedTx := e.GetQueuedTransactions()
+	queuedTx := e.GetHeaderSubscriptions()
 	wg := sync.WaitGroup{}
 	wg.Add(len(queuedTx))
 
@@ -289,7 +289,7 @@ func (e *EthereumClient) WaitForTransactions() error {
 			if err := sub.Wait(); err != nil {
 				errGroup = multierror.Append(errGroup, err)
 			}
-			e.DeleteQueuedTransaction(txHash)
+			e.DeleteHeaderEventSubscription(txHash)
 		}()
 	}
 	wg.Wait()
@@ -297,30 +297,30 @@ func (e *EthereumClient) WaitForTransactions() error {
 	return errGroup
 }
 
-// GetQueuedTransactions returns a duplicate map of the queued transactions
-func (e *EthereumClient) GetQueuedTransactions() map[string]EthereumTransactionConfirmer {
+// GetHeaderSubscriptions returns a duplicate map of the queued transactions
+func (e *EthereumClient) GetHeaderSubscriptions() map[string]HeaderEventSubscription {
 	e.mutex.Lock()
 	defer e.mutex.Unlock()
 
-	newMap := map[string]EthereumTransactionConfirmer{}
-	for k, v := range e.queuedTransactions {
+	newMap := map[string]HeaderEventSubscription{}
+	for k, v := range e.headerSubscriptions {
 		newMap[k] = v
 	}
 	return newMap
 }
 
-// AddQueuedTransaction adds a new header subscriber within the client to receive new headers
-func (e *EthereumClient) AddQueuedTransaction(key string, subscriber EthereumTransactionConfirmer) {
+// AddHeaderSubscription adds a new header subscriber within the client to receive new headers
+func (e *EthereumClient) AddHeaderEventSubscription(key string, subscriber HeaderEventSubscription) {
 	e.mutex.Lock()
 	defer e.mutex.Unlock()
-	e.queuedTransactions[key] = subscriber
+	e.headerSubscriptions[key] = subscriber
 }
 
-// DeleteQueuedTransaction removes a header subscriber from the map
-func (e *EthereumClient) DeleteQueuedTransaction(key string) {
+// DeleteHeaderSubscription removes a header subscriber from the map
+func (e *EthereumClient) DeleteHeaderEventSubscription(key string) {
 	e.mutex.Lock()
 	defer e.mutex.Unlock()
-	delete(e.queuedTransactions, key)
+	delete(e.headerSubscriptions, key)
 }
 
 func (e *EthereumClient) newHeadersLoop() {
@@ -357,7 +357,7 @@ func (e *EthereumClient) subscribeToNewHeaders() error {
 				Str("Block Number", header.Number.String()).
 				Msg("Received block header")
 
-			queuedTx := e.GetQueuedTransactions()
+			queuedTx := e.GetHeaderSubscriptions()
 			for _, sub := range queuedTx {
 				if err := sub.ReceiveHeader(header); err != nil {
 					log.Error().Msgf("Error while sending header to receiver: %v", err)
@@ -392,7 +392,11 @@ func (e *EthereumClient) isTxConfirmed(txHash common.Hash) (bool, error) {
 }
 
 // errorReason decodes tx revert reason
-func (e *EthereumClient) errorReason(b ethereum.ContractCaller, tx *types.Transaction, receipt *types.Receipt) (string, error) {
+func (e *EthereumClient) errorReason(
+	b ethereum.ContractCaller,
+	tx *types.Transaction,
+	receipt *types.Receipt,
+) (string, error) {
 	chID, err := e.Client.NetworkID(context.Background())
 	if err != nil {
 		return "", err
@@ -416,13 +420,7 @@ func (e *EthereumClient) errorReason(b ethereum.ContractCaller, tx *types.Transa
 	return abi.UnpackRevert(res)
 }
 
-// EthereumTransactionConfirmer is an interface for allowing callbacks when the client receives a new header
-type EthereumTransactionConfirmer interface {
-	ReceiveHeader(header *types.Header) error
-	Wait() error
-}
-
-// TransactionConfirmer is an implementation of EthereumTransactionConfirmer that checks whether tx are confirmed
+// TransactionConfirmer is an implementation of HeaderEventSubscription that checks whether tx are confirmed
 type TransactionConfirmer struct {
 	minConfirmations int
 	confirmations    int
@@ -449,7 +447,7 @@ func NewTransactionConfirmer(eth *EthereumClient, txHash common.Hash, minConfirm
 	return tc
 }
 
-// ReceiveHeader the implementation of the EthereumTransactionConfirmer that receives each block header and checks
+// ReceiveHeader the implementation of the HeaderEventSubscription that receives each block header and checks
 // tx confirmation
 func (t *TransactionConfirmer) ReceiveHeader(header *types.Header) error {
 	block, err := t.eth.Client.BlockByNumber(context.Background(), header.Number)

--- a/contracts/contract_models.go
+++ b/contracts/contract_models.go
@@ -41,7 +41,6 @@ type SetOraclesOptions struct {
 type FluxAggregator interface {
 	Address() string
 	Fund(fromWallet client.BlockchainWallet, ethAmount, linkAmount *big.Float) error
-	AwaitNextRoundFinalized(ctx context.Context) error
 	LatestRound(ctx context.Context) (*big.Int, error)
 	GetContractData(ctxt context.Context) (*FluxAggregatorData, error)
 	UpdateAvailableFunds(ctx context.Context, fromWallet client.BlockchainWallet) error

--- a/suite/contracts/contracts_flux_test.go
+++ b/suite/contracts/contracts_flux_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Flux monitor suite", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			err = fluxInstance.UpdateAvailableFunds(context.Background(), s.Wallets.Default())
 			Expect(err).ShouldNot(HaveOccurred())
-			err = s.Client.WaitForTransactions()
+			err = s.Client.WaitForEvents()
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 		By("Funding Chainlink nodes", func() {
@@ -74,7 +74,7 @@ var _ = Describe("Flux monitor suite", func() {
 					RestartDelayRounds: 0,
 				})
 			Expect(err).ShouldNot(HaveOccurred())
-			err = s.Client.WaitForTransactions()
+			err = s.Client.WaitForEvents()
 			Expect(err).ShouldNot(HaveOccurred())
 			oracles, err := fluxInstance.GetOracles(context.Background())
 			Expect(err).ShouldNot(HaveOccurred())

--- a/suite/contracts/contracts_flux_test.go
+++ b/suite/contracts/contracts_flux_test.go
@@ -26,6 +26,7 @@ var _ = Describe("Flux monitor suite", func() {
 		fluxInstance  contracts.FluxAggregator
 		err           error
 	)
+	fluxRoundTimeout := time.Minute * 2
 
 	BeforeEach(func() {
 		By("Deploying the environment", func() {
@@ -99,35 +100,39 @@ var _ = Describe("Flux monitor suite", func() {
 		It("performs two rounds and has withdrawable payments for oracles", func() {
 			err = adapter.SetVariable(5)
 			Expect(err).ShouldNot(HaveOccurred())
-			err = fluxInstance.AwaitNextRoundFinalized(context.Background())
+
+			fluxRound := contracts.NewFluxAggregatorRoundConfirmer(fluxInstance, big.NewInt(1), fluxRoundTimeout)
+			s.Client.AddHeaderEventSubscription(fluxInstance.Address(), fluxRound)
+			err = s.Client.WaitForEvents()
 			Expect(err).ShouldNot(HaveOccurred())
-			{
-				data, err := fluxInstance.GetContractData(context.Background())
-				Expect(err).ShouldNot(HaveOccurred())
-				log.Info().Interface("data", data).Msg("Round data")
-				Expect(len(data.Oracles)).Should(Equal(3))
-				Expect(data.LatestRoundData.Answer.Int64()).Should(Equal(int64(5)))
-				Expect(data.LatestRoundData.RoundId.Int64()).Should(Equal(int64(1)))
-				Expect(data.LatestRoundData.AnsweredInRound.Int64()).Should(Equal(int64(1)))
-				Expect(data.AvailableFunds.Int64()).Should(Equal(int64(999999999999999997)))
-				Expect(data.AllocatedFunds.Int64()).Should(Equal(int64(3)))
-			}
+
+			data, err := fluxInstance.GetContractData(context.Background())
+			Expect(err).ShouldNot(HaveOccurred())
+			log.Info().Interface("data", data).Msg("Round data")
+			Expect(len(data.Oracles)).Should(Equal(3))
+			Expect(data.LatestRoundData.Answer.Int64()).Should(Equal(int64(5)))
+			Expect(data.LatestRoundData.RoundId.Int64()).Should(Equal(int64(1)))
+			Expect(data.LatestRoundData.AnsweredInRound.Int64()).Should(Equal(int64(1)))
+			Expect(data.AvailableFunds.Int64()).Should(Equal(int64(999999999999999997)))
+			Expect(data.AllocatedFunds.Int64()).Should(Equal(int64(3)))
 
 			err = adapter.SetVariable(6)
 			Expect(err).ShouldNot(HaveOccurred())
-			err = fluxInstance.AwaitNextRoundFinalized(context.Background())
+
+			fluxRound = contracts.NewFluxAggregatorRoundConfirmer(fluxInstance, big.NewInt(2), fluxRoundTimeout)
+			s.Client.AddHeaderEventSubscription(fluxInstance.Address(), fluxRound)
+			err = s.Client.WaitForEvents()
 			Expect(err).ShouldNot(HaveOccurred())
-			{
-				data, err := fluxInstance.GetContractData(context.Background())
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(len(data.Oracles)).Should(Equal(3))
-				Expect(data.LatestRoundData.Answer.Int64()).Should(Equal(int64(6)))
-				Expect(data.LatestRoundData.RoundId.Int64()).Should(Equal(int64(2)))
-				Expect(data.LatestRoundData.AnsweredInRound.Int64()).Should(Equal(int64(2)))
-				Expect(data.AvailableFunds.Int64()).Should(Equal(int64(999999999999999994)))
-				Expect(data.AllocatedFunds.Int64()).Should(Equal(int64(6)))
-				log.Info().Interface("data", data).Msg("Round data")
-			}
+
+			data, err = fluxInstance.GetContractData(context.Background())
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(len(data.Oracles)).Should(Equal(3))
+			Expect(data.LatestRoundData.Answer.Int64()).Should(Equal(int64(6)))
+			Expect(data.LatestRoundData.RoundId.Int64()).Should(Equal(int64(2)))
+			Expect(data.LatestRoundData.AnsweredInRound.Int64()).Should(Equal(int64(2)))
+			Expect(data.AvailableFunds.Int64()).Should(Equal(int64(999999999999999994)))
+			Expect(data.AllocatedFunds.Int64()).Should(Equal(int64(6)))
+			log.Info().Interface("data", data).Msg("Round data")
 
 			for _, oracleAddr := range nodeAddresses {
 				payment, _ := fluxInstance.WithdrawablePayment(context.Background(), oracleAddr)

--- a/suite/contracts/contracts_keeper_test.go
+++ b/suite/contracts/contracts_keeper_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Keeper suite", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			err = consumer.Fund(s.Wallets.Default(), big.NewFloat(0), big.NewFloat(1))
 			Expect(err).ShouldNot(HaveOccurred())
-			err = s.Client.WaitForTransactions()
+			err = s.Client.WaitForEvents()
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 		By("Registering upkeep target", func() {
@@ -112,7 +112,7 @@ var _ = Describe("Keeper suite", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			err = s.Link.TransferAndCall(s.Wallets.Default(), registrar.Address(), big.NewInt(9e18), req)
 			Expect(err).ShouldNot(HaveOccurred())
-			err = s.Client.WaitForTransactions()
+			err = s.Client.WaitForEvents()
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 		By("Adding Keepers and a job", func() {
@@ -137,7 +137,7 @@ var _ = Describe("Keeper suite", func() {
 				FromAddress:     na,
 			})
 			Expect(err).ShouldNot(HaveOccurred())
-			err = s.Client.WaitForTransactions()
+			err = s.Client.WaitForEvents()
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 	})

--- a/suite/contracts/contracts_ocr_test.go
+++ b/suite/contracts/contracts_ocr_test.go
@@ -66,7 +66,7 @@ var _ = Describe("OCR Feed", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			err = ocrInstance.Fund(defaultWallet, nil, big.NewFloat(2))
 			Expect(err).ShouldNot(HaveOccurred())
-			err = suiteSetup.Client.WaitForTransactions()
+			err = suiteSetup.Client.WaitForEvents()
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
@@ -111,7 +111,7 @@ var _ = Describe("OCR Feed", func() {
 		By("Checking OCR rounds", func() {
 			err := ocrInstance.RequestNewRound(defaultWallet)
 			Expect(err).ShouldNot(HaveOccurred())
-			err = suiteSetup.Client.WaitForTransactions()
+			err = suiteSetup.Client.WaitForEvents()
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Wait for a round

--- a/suite/contracts/contracts_vrf_test.go
+++ b/suite/contracts/contracts_vrf_test.go
@@ -53,7 +53,7 @@ var _ = Describe("VRF suite", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			_, err = s.Deployer.DeployVRFContract(s.Wallets.Default())
 			Expect(err).ShouldNot(HaveOccurred())
-			err = s.Client.WaitForTransactions()
+			err = s.Client.WaitForEvents()
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 		By("Creating jobs and registering proving keys", func() {

--- a/suite/refill/eth_refill_test.go
+++ b/suite/refill/eth_refill_test.go
@@ -55,7 +55,7 @@ var _ = Describe("FluxAggregator ETH Refill", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			err = fluxInstance.UpdateAvailableFunds(context.Background(), s.Wallets.Default())
 			Expect(err).ShouldNot(HaveOccurred())
-			err = s.Client.WaitForTransactions()
+			err = s.Client.WaitForEvents()
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
@@ -70,7 +70,7 @@ var _ = Describe("FluxAggregator ETH Refill", func() {
 					RestartDelayRounds: 0,
 				},
 			)
-			err = s.Client.WaitForTransactions()
+			err = s.Client.WaitForEvents()
 			Expect(err).ShouldNot(HaveOccurred())
 			oracles, err := fluxInstance.GetOracles(context.Background())
 			Expect(err).ShouldNot(HaveOccurred())
@@ -102,7 +102,7 @@ var _ = Describe("FluxAggregator ETH Refill", func() {
 		By("Funding ETH for a single round", func() {
 			err = actions.FundChainlinkNodes(nodes, s.Client, s.Wallets.Default(), big.NewFloat(.01), nil)
 			Expect(err).ShouldNot(HaveOccurred())
-			err = s.Client.WaitForTransactions()
+			err = s.Client.WaitForEvents()
 			Expect(err).ShouldNot(HaveOccurred())
 			err = adapter.SetVariable(6)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -122,7 +122,7 @@ var _ = Describe("FluxAggregator ETH Refill", func() {
 		It("should refill and await the next round", func() {
 			err = actions.FundChainlinkNodes(nodes, s.Client, s.Wallets.Default(), big.NewFloat(2), nil)
 			Expect(err).ShouldNot(HaveOccurred())
-			err = s.Client.WaitForTransactions()
+			err = s.Client.WaitForEvents()
 			Expect(err).ShouldNot(HaveOccurred())
 			err = fluxInstance.AwaitNextRoundFinalized(context.Background())
 			Expect(err).ShouldNot(HaveOccurred())

--- a/suite/refill/eth_refill_test.go
+++ b/suite/refill/eth_refill_test.go
@@ -25,6 +25,7 @@ var _ = Describe("FluxAggregator ETH Refill", func() {
 		err           error
 		fluxInstance  contracts.FluxAggregator
 	)
+	fluxRoundTimeout := time.Minute * 2
 
 	BeforeEach(func() {
 		By("Deploying the environment", func() {
@@ -106,15 +107,21 @@ var _ = Describe("FluxAggregator ETH Refill", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			err = adapter.SetVariable(6)
 			Expect(err).ShouldNot(HaveOccurred())
-			err = fluxInstance.AwaitNextRoundFinalized(context.Background())
+
+			fluxRound := contracts.NewFluxAggregatorRoundConfirmer(fluxInstance, big.NewInt(1), fluxRoundTimeout)
+			s.Client.AddHeaderEventSubscription(fluxInstance.Address(), fluxRound)
+			err = s.Client.WaitForEvents()
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
 		By("Draining ETH on the nodes", func() {
 			err = adapter.SetVariable(5)
 			Expect(err).ShouldNot(HaveOccurred())
-			err = fluxInstance.AwaitNextRoundFinalized(context.Background())
-			Expect(err).Should(HaveOccurred())
+
+			fluxRound := contracts.NewFluxAggregatorRoundConfirmer(fluxInstance, big.NewInt(2), fluxRoundTimeout)
+			s.Client.AddHeaderEventSubscription(fluxInstance.Address(), fluxRound)
+			err = s.Client.WaitForEvents()
+			Expect(err).ShouldNot(HaveOccurred())
 		})
 	})
 
@@ -124,8 +131,12 @@ var _ = Describe("FluxAggregator ETH Refill", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			err = s.Client.WaitForEvents()
 			Expect(err).ShouldNot(HaveOccurred())
-			err = fluxInstance.AwaitNextRoundFinalized(context.Background())
+
+			fluxRound := contracts.NewFluxAggregatorRoundConfirmer(fluxInstance, big.NewInt(3), fluxRoundTimeout)
+			s.Client.AddHeaderEventSubscription(fluxInstance.Address(), fluxRound)
+			err = s.Client.WaitForEvents()
 			Expect(err).ShouldNot(HaveOccurred())
+
 			data, err := fluxInstance.GetContractData(context.Background())
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(data.LatestRoundData.Answer.Int64()).Should(Equal(int64(5)))


### PR DESCRIPTION
PR is designed to avoid polling in tests with retry mechanisms, rather implementing an interface that can be used with contexts to allow for smarter polling on each new block header.

For example:
```go
// OCRTransmissionConfirmer checks on each block header whether an OCR transmission has been received
type OCRTransmissionConfirmer struct{
	// Properties about the OCR feed
}

// ReceiveHeader checks whether an OCR transmission has been received on each block header
func (o *OCRTransmissionConfirmer) ReceiveHeader(*types.Header) error {
	// OCR checking logic here
	return nil
}

// Wait blocks until the OCR transmission has been received
func (o *OCRTransmissionConfirmer) Wait() error {
	// Blocking channel action here with context that waits
	return nil
}

// TransmissionDetails returns all details about the transmission
func (o *OCRTransmissionConfirmer) TransmissionDetails() error {
	return transmission
}
```

You'd then add that subscriber above to the client within your test:
```go
suiteSetup.Client.AddHeaderEventSubscription("ocr-0x123456", ocrSubscriberImplementation)
err = suiteSetup.Client.WaitForEvents()
Expect(err).ShouldNot(HaveOccurred())
ocrSubscriberImplementation.TransmissionDetails()
```

This way, you can queue multiple event subscriptions within the tests that only poll when a new block header is received, rather than on a static ticker.