### PR TITLE
Prepare Config for Use in Chainlink Repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,50 @@ The framework is primarilly intended to facillitate testing chainlink features a
 This framework is still very much a work in progress, and will have frequent changes, many of which will probably be
 breaking.
 
+## Usage
+
+```go
+var _ = Describe("Basic Contract Interactions", func() {
+	var suiteSetup *actions.DefaultSuiteSetup
+	var defaultWallet client.BlockchainWallet
+
+	BeforeEach(func() {
+		By("Deploying the environment", func() {
+			confFileLocation, err := filepath.Abs("../") // Get the absolute path of the test suite's root directory
+            Expect(err).ShouldNot(HaveOccurred())
+			suiteSetup, err = actions.DefaultLocalSetup(
+				environment.NewChainlinkCluster(0),
+				client.NewNetworkFromConfig,
+				tools.ProjectRoot, // Folder location of the
+			)
+			Expect(err).ShouldNot(HaveOccurred())
+			defaultWallet = suiteSetup.Wallets.Default()
+		})
+	})
+
+	It("exercises basic contract usage", func() {
+		By("deploying the storage contract", func() {
+			// Deploy storage
+			storeInstance, err := suiteSetup.Deployer.DeployStorageContract(defaultWallet)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			testVal := big.NewInt(5)
+
+			// Interact with contract
+			err = storeInstance.Set(testVal)
+			Expect(err).ShouldNot(HaveOccurred())
+			val, err := storeInstance.Get(context.Background())
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(val).To(Equal(testVal))
+		})
+    })
+
+    AfterEach(func() {
+		By("Tearing down the environment", suiteSetup.TearDown())
+	})
+})
+```
+
 ## Execution Environment
 
 Ephemeral environments are automatically deployed with Kubernetes. To run tests, you either need a deployed cluster 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ breaking.
 
 ## Usage
 
+A simple example on deploying and interaction with a simple contract using this framework and [Ginkgo](https://github.com/onsi/ginkgo)
+
 ```go
 var _ = Describe("Basic Contract Interactions", func() {
 	var suiteSetup *actions.DefaultSuiteSetup
@@ -26,7 +28,7 @@ var _ = Describe("Basic Contract Interactions", func() {
 			suiteSetup, err = actions.DefaultLocalSetup(
 				environment.NewChainlinkCluster(0),
 				client.NewNetworkFromConfig,
-				tools.ProjectRoot, // Folder location of the
+				confFileLocation, // Directory where config.yml is placed
 			)
 			Expect(err).ShouldNot(HaveOccurred())
 			defaultWallet = suiteSetup.Wallets.Default()
@@ -58,7 +60,7 @@ var _ = Describe("Basic Contract Interactions", func() {
 
 ## Execution Environment
 
-Ephemeral environments are automatically deployed with Kubernetes. To run tests, you either need a deployed cluster 
+Ephemeral environments are automatically deployed with Kubernetes. To run tests, you either need a deployed cluster
 in an environment, or a local installation.
 
 ### Locally
@@ -71,12 +73,12 @@ minikube start
 
 ### Remotely
 
-To run against a remote Kubernetes cluster, ensure your current context is the cluster you want to run against as the 
+To run against a remote Kubernetes cluster, ensure your current context is the cluster you want to run against as the
 framework always uses current context.
 
 ## Test Execution
 
-This framework advises the use of [Ginkgo](https://github.com/onsi/ginkgo) for test execution, but tests still can be 
+This framework advises the use of [Ginkgo](https://github.com/onsi/ginkgo) for test execution, but tests still can be
 ran with the go CLI.
 
 ### Ginkgo

--- a/actions/setup.go
+++ b/actions/setup.go
@@ -14,7 +14,6 @@ import (
 	"github.com/smartcontractkit/integrations-framework/config"
 	"github.com/smartcontractkit/integrations-framework/contracts"
 	"github.com/smartcontractkit/integrations-framework/environment"
-	"github.com/smartcontractkit/integrations-framework/tools"
 )
 
 const (
@@ -81,9 +80,29 @@ func DefaultLocalSetup(
 	}, nil
 }
 
+// DefaultLocalSetupSpecifyConfig gives a default testing environment setup with a specified config file path
+func DefaultLocalSetupSpecifyConfig(
+	envInitFunc environment.K8sEnvSpecInit,
+	initFunc client.BlockchainNetworkInit,
+	configPath string,
+) (*DefaultSuiteSetup, error) {
+	s, err := DefaultLocalSetup(envInitFunc, initFunc)
+	if err != nil {
+		return nil, err
+	}
+	specifiedConf, err := config.NewConfigWithPath(config.LocalConfig, configPath)
+	if err != nil {
+		return nil, err
+	}
+	s.Config = specifiedConf
+	return s, err
+}
+
+// TearDown checks for test failure, writes logs if there is one, then tears down the test environment, based on the
+// keep_environments config value
 func (s *DefaultSuiteSetup) TearDown() func() {
 	if ginkgo.CurrentGinkgoTestDescription().Failed { // If a test fails, dump logs
-		logsFolder := tools.ProjectRoot + "/logs/"
+		logsFolder := filepath.Join(s.Config.ConfigFileLocation, "/logs/")
 		if _, err := os.Stat(logsFolder); os.IsNotExist(err) {
 			if err = os.Mkdir(logsFolder, 0755); err != nil {
 				log.Err(err).Str("Log Folder", logsFolder).Msg("Error creating logs directory")

--- a/actions/setup.go
+++ b/actions/setup.go
@@ -35,8 +35,9 @@ type DefaultSuiteSetup struct {
 func DefaultLocalSetup(
 	envInitFunc environment.K8sEnvSpecInit,
 	initFunc client.BlockchainNetworkInit,
+	configPath string,
 ) (*DefaultSuiteSetup, error) {
-	conf, err := config.NewConfig(config.LocalConfig)
+	conf, err := config.NewConfig(config.LocalConfig, configPath)
 	if err != nil {
 		return nil, err
 	}
@@ -78,24 +79,6 @@ func DefaultLocalSetup(
 		Link:     link,
 		Env:      env,
 	}, nil
-}
-
-// DefaultLocalSetupSpecifyConfig gives a default testing environment setup with a specified config file path
-func DefaultLocalSetupSpecifyConfig(
-	envInitFunc environment.K8sEnvSpecInit,
-	initFunc client.BlockchainNetworkInit,
-	configPath string,
-) (*DefaultSuiteSetup, error) {
-	s, err := DefaultLocalSetup(envInitFunc, initFunc)
-	if err != nil {
-		return nil, err
-	}
-	specifiedConf, err := config.NewConfigWithPath(config.LocalConfig, configPath)
-	if err != nil {
-		return nil, err
-	}
-	s.Config = specifiedConf
-	return s, err
 }
 
 // TearDown checks for test failure, writes logs if there is one, then tears down the test environment, based on the

--- a/client/blockchain_test.go
+++ b/client/blockchain_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"github.com/smartcontractkit/integrations-framework/config"
+	"github.com/smartcontractkit/integrations-framework/tools"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -13,7 +14,7 @@ var _ = Describe("Client", func() {
 
 	BeforeEach(func() {
 		var err error
-		conf, err = config.NewConfig(config.LocalConfig)
+		conf, err = config.NewConfig(config.LocalConfig, tools.ProjectRoot)
 		Expect(err).ShouldNot(HaveOccurred())
 	})
 

--- a/config/config.go
+++ b/config/config.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"github.com/smartcontractkit/integrations-framework/tools"
 	"github.com/spf13/viper"
 )
@@ -20,13 +21,14 @@ const (
 
 // Config is the overall config for the framework, holding configurations for supported networks
 type Config struct {
-	Network          string                    `mapstructure:"network" yaml:"network"`
-	Networks         map[string]*NetworkConfig `mapstructure:"networks" yaml:"networks"`
-	Retry            *RetryConfig              `mapstructure:"retry" yaml:"retry"`
-	Apps             AppConfig                 `mapstructure:"apps" yaml:"apps"`
-	Kubernetes       KubernetesConfig          `mapstructure:"kubernetes" yaml:"kubernetes"`
-	KeepEnvironments string                    `mapstructure:"keep_environments" yaml:"keep_environments"`
-	DefaultKeyStore  string
+	Network            string                    `mapstructure:"network" yaml:"network"`
+	Networks           map[string]*NetworkConfig `mapstructure:"networks" yaml:"networks"`
+	Retry              *RetryConfig              `mapstructure:"retry" yaml:"retry"`
+	Apps               AppConfig                 `mapstructure:"apps" yaml:"apps"`
+	Kubernetes         KubernetesConfig          `mapstructure:"kubernetes" yaml:"kubernetes"`
+	KeepEnvironments   string                    `mapstructure:"keep_environments" yaml:"keep_environments"`
+	DefaultKeyStore    string
+	ConfigFileLocation string
 }
 
 // GetNetworkConfig finds a specified network config based on its name
@@ -73,18 +75,26 @@ type ChainlinkConfig struct {
 
 // NewConfig creates a new configuration instance via viper from env vars, config file, or a secret store
 func NewConfig(configType ConfigurationType) (*Config, error) {
+	return NewConfigWithPath(configType, tools.ProjectRoot)
+}
+
+func NewConfigWithPath(configType ConfigurationType, configPath string) (*Config, error) {
 	v := viper.New()
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	v.AutomaticEnv()
 	v.SetConfigName("config")
 	v.SetConfigType("yml")
+	v.AddConfigPath(configPath)
 	v.AddConfigPath(tools.ProjectRoot)
 
 	if err := v.ReadInConfig(); err != nil {
 		return nil, err
 	}
 
-	conf := &Config{}
+	conf := &Config{
+		ConfigFileLocation: strings.TrimRight(v.ConfigFileUsed(), "config.yml"),
+	}
+	log.Info().Str("File Location", v.ConfigFileUsed()).Msg("Loading config file")
 	err := v.Unmarshal(conf)
 	for _, networkConf := range conf.Networks {
 		networkConf.PrivateKeyStore = NewPrivateKeyStore(configType, networkConf)

--- a/config/config.go
+++ b/config/config.go
@@ -74,11 +74,7 @@ type ChainlinkConfig struct {
 }
 
 // NewConfig creates a new configuration instance via viper from env vars, config file, or a secret store
-func NewConfig(configType ConfigurationType) (*Config, error) {
-	return NewConfigWithPath(configType, tools.ProjectRoot)
-}
-
-func NewConfigWithPath(configType ConfigurationType, configPath string) (*Config, error) {
+func NewConfig(configType ConfigurationType, configPath string) (*Config, error) {
 	v := viper.New()
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	v.AutomaticEnv()

--- a/environment/cli/cmd/create.go
+++ b/environment/cli/cmd/create.go
@@ -2,10 +2,12 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/rs/zerolog/log"
 	"github.com/smartcontractkit/integrations-framework/client"
 	"github.com/smartcontractkit/integrations-framework/config"
 	"github.com/smartcontractkit/integrations-framework/environment"
+	"github.com/smartcontractkit/integrations-framework/tools"
 	"github.com/spf13/cobra"
 )
 
@@ -29,7 +31,7 @@ func createRunE(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	cfg, err := config.NewConfig(config.LocalConfig)
+	cfg, err := config.NewConfig(config.LocalConfig, tools.ProjectRoot)
 	if err != nil {
 		return err
 	}

--- a/environment/k8s_environment_test.go
+++ b/environment/k8s_environment_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/smartcontractkit/integrations-framework/client"
 	"github.com/smartcontractkit/integrations-framework/config"
+	"github.com/smartcontractkit/integrations-framework/tools"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -15,7 +16,7 @@ var _ = Describe("Environment functionality", func() {
 
 	BeforeEach(func() {
 		var err error
-		conf, err = config.NewConfig(config.LocalConfig)
+		conf, err = config.NewConfig(config.LocalConfig, tools.ProjectRoot)
 		Expect(err).ShouldNot(HaveOccurred())
 	})
 

--- a/suite/contracts/contracts_cron_test.go
+++ b/suite/contracts/contracts_cron_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/smartcontractkit/integrations-framework/actions"
 	"github.com/smartcontractkit/integrations-framework/client"
 	"github.com/smartcontractkit/integrations-framework/environment"
+	"github.com/smartcontractkit/integrations-framework/tools"
 )
 
 var _ = Describe("Cronjob suite", func() {
@@ -24,6 +25,7 @@ var _ = Describe("Cronjob suite", func() {
 			s, err = actions.DefaultLocalSetup(
 				environment.NewChainlinkCluster(1),
 				client.NewNetworkFromConfig,
+				tools.ProjectRoot,
 			)
 			Expect(err).ShouldNot(HaveOccurred())
 			nodes, err = environment.GetChainlinkClients(s.Env)

--- a/suite/contracts/contracts_flux_test.go
+++ b/suite/contracts/contracts_flux_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/smartcontractkit/integrations-framework/actions"
+	"github.com/smartcontractkit/integrations-framework/tools"
 
 	"github.com/ethereum/go-ethereum/common"
 	. "github.com/onsi/ginkgo"
@@ -33,6 +34,7 @@ var _ = Describe("Flux monitor suite", func() {
 			s, err = actions.DefaultLocalSetup(
 				environment.NewChainlinkCluster(3),
 				client.NewNetworkFromConfig,
+				tools.ProjectRoot,
 			)
 			Expect(err).ShouldNot(HaveOccurred())
 			nodes, err = environment.GetChainlinkClients(s.Env)

--- a/suite/contracts/contracts_keeper_test.go
+++ b/suite/contracts/contracts_keeper_test.go
@@ -3,6 +3,8 @@ package contracts
 import (
 	"context"
 	"errors"
+	"math/big"
+
 	"github.com/avast/retry-go"
 	"github.com/ethereum/go-ethereum/common"
 	. "github.com/onsi/ginkgo"
@@ -12,7 +14,7 @@ import (
 	"github.com/smartcontractkit/integrations-framework/client"
 	"github.com/smartcontractkit/integrations-framework/contracts"
 	"github.com/smartcontractkit/integrations-framework/environment"
-	"math/big"
+	"github.com/smartcontractkit/integrations-framework/tools"
 )
 
 var _ = Describe("Keeper suite", func() {
@@ -32,6 +34,7 @@ var _ = Describe("Keeper suite", func() {
 				// need to register at least 5 nodes to perform upkeep
 				environment.NewChainlinkCluster(5),
 				client.NewNetworkFromConfig,
+				tools.ProjectRoot,
 			)
 			Expect(err).ShouldNot(HaveOccurred())
 			nodes, err = environment.GetChainlinkClients(s.Env)

--- a/suite/contracts/contracts_ocr_test.go
+++ b/suite/contracts/contracts_ocr_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/smartcontractkit/integrations-framework/client"
 	"github.com/smartcontractkit/integrations-framework/contracts"
 	"github.com/smartcontractkit/integrations-framework/environment"
+	"github.com/smartcontractkit/integrations-framework/tools"
 )
 
 var _ = Describe("OCR Feed", func() {
@@ -28,6 +29,7 @@ var _ = Describe("OCR Feed", func() {
 			suiteSetup, err = actions.DefaultLocalSetup(
 				environment.NewChainlinkCluster(5),
 				client.NewNetworkFromConfig,
+				tools.ProjectRoot,
 			)
 			Expect(err).ShouldNot(HaveOccurred())
 			adapter, err = environment.GetExternalAdapter(suiteSetup.Env)

--- a/suite/contracts/contracts_runlog_test.go
+++ b/suite/contracts/contracts_runlog_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/smartcontractkit/integrations-framework/client"
 	"github.com/smartcontractkit/integrations-framework/contracts"
 	"github.com/smartcontractkit/integrations-framework/environment"
+	"github.com/smartcontractkit/integrations-framework/tools"
 )
 
 var _ = Describe("Direct request suite", func() {
@@ -35,6 +36,7 @@ var _ = Describe("Direct request suite", func() {
 			s, err = actions.DefaultLocalSetup(
 				environment.NewChainlinkCluster(1),
 				client.NewNetworkFromConfig,
+				tools.ProjectRoot,
 			)
 			Expect(err).ShouldNot(HaveOccurred())
 			adapter, err = environment.GetExternalAdapter(s.Env)

--- a/suite/contracts/contracts_test.go
+++ b/suite/contracts/contracts_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/smartcontractkit/integrations-framework/actions"
 	"github.com/smartcontractkit/integrations-framework/contracts"
 	"github.com/smartcontractkit/integrations-framework/environment"
+	"github.com/smartcontractkit/integrations-framework/tools"
 
 	"github.com/smartcontractkit/integrations-framework/client"
 
@@ -24,6 +25,7 @@ var _ = Describe("Basic Contract Interactions", func() {
 			suiteSetup, err = actions.DefaultLocalSetup(
 				environment.NewChainlinkCluster(0),
 				client.NewNetworkFromConfig,
+				tools.ProjectRoot,
 			)
 			Expect(err).ShouldNot(HaveOccurred())
 			defaultWallet = suiteSetup.Wallets.Default()

--- a/suite/contracts/contracts_vrf_test.go
+++ b/suite/contracts/contracts_vrf_test.go
@@ -2,6 +2,8 @@ package contracts
 
 import (
 	"context"
+	"math/big"
+
 	"github.com/avast/retry-go"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -12,7 +14,7 @@ import (
 	"github.com/smartcontractkit/integrations-framework/client"
 	"github.com/smartcontractkit/integrations-framework/contracts"
 	"github.com/smartcontractkit/integrations-framework/environment"
-	"math/big"
+	"github.com/smartcontractkit/integrations-framework/tools"
 )
 
 var _ = Describe("VRF suite", func() {
@@ -31,6 +33,7 @@ var _ = Describe("VRF suite", func() {
 			s, err = actions.DefaultLocalSetup(
 				environment.NewChainlinkCluster(1),
 				client.NewNetworkFromConfig,
+				tools.ProjectRoot,
 			)
 			Expect(err).ShouldNot(HaveOccurred())
 			nodes, err = environment.GetChainlinkClients(s.Env)

--- a/suite/refill/eth_refill_test.go
+++ b/suite/refill/eth_refill_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/smartcontractkit/integrations-framework/client"
 	"github.com/smartcontractkit/integrations-framework/contracts"
 	"github.com/smartcontractkit/integrations-framework/environment"
+	"github.com/smartcontractkit/integrations-framework/tools"
 )
 
 var _ = Describe("FluxAggregator ETH Refill", func() {
@@ -32,6 +33,7 @@ var _ = Describe("FluxAggregator ETH Refill", func() {
 			s, err = actions.DefaultLocalSetup(
 				environment.NewChainlinkCluster(3),
 				client.NewNetworkFromConfig,
+				tools.ProjectRoot,
 			)
 			Expect(err).ShouldNot(HaveOccurred())
 			adapter, err = environment.GetExternalAdapter(s.Env)

--- a/tools/project_path.go
+++ b/tools/project_path.go
@@ -6,7 +6,6 @@ import (
 )
 
 var (
-	_, b, _, _ = runtime.Caller(0)
-	// Root folder of this project
+	_, b, _, _  = runtime.Caller(0)
 	ProjectRoot = filepath.Join(filepath.Dir(b), "/..")
 )


### PR DESCRIPTION
# Config Loading Options

We had a similar style to this config loading setup earlier on in the project; we moved away from it because it was annoying having to specify the config. Well, we're back. The idea is to move the test suite into the main chainlink repo, and in order for things like reading the config, and recording log files properly, there doesn't seem to be many ways around just providing the config path. 

## Other Attempts

I open the floor for discussion, as I've tried a few different ways to do this, and they didn't pan out. All attempts to automatically sense the directory from where the calls were being made led to one of the following.

1. It kept defaulting to the `integrations-framework` library
2. The root directory was assumed to be some compiled Ginkgo binary in a randomly generated `var` folder
3. The calling file was an internal `Ginkgo` runner
4. Getting the current working directory, which is obviously great if you are calling tests from the proper directory. Not such a great solution otherwise.

So I'm left at this option, which works fine, tests are running in the chainlink repo. But it feels icky.

## Usage

Addition of this setup action
```go
// DefaultLocalSetupSpecifyConfig gives a default testing environment setup with a specified config file path
func DefaultLocalSetupSpecifyConfig(
	envInitFunc environment.K8sEnvSpecInit,
	initFunc client.BlockchainNetworkInit,
	configPath string,
) (*DefaultSuiteSetup, error) {
	s, err := DefaultLocalSetup(envInitFunc, initFunc)
	if err != nil {
		return nil, err
	}
	specifiedConf, err := config.NewConfigWithPath(config.LocalConfig, configPath)
	if err != nil {
		return nil, err
	}
	s.Config = specifiedConf
	return s, err
}
```

Example usage in a `BeforeEach` block I've setup for the main chainlink repo:

```go
BeforeEach(func() {
  confFileLocation, err = filepath.Abs("../") // Get the absolute path of the test suite's root directory
  Expect(err).ShouldNot(HaveOccurred()) 
  suiteSetup, err = actions.DefaultLocalSetupSpecifyConfig(
	  environment.NewChainlinkCluster(1),
	  client.NewNetworkFromConfig,
	  confFileLocation,
  )
  Expect(err).ShouldNot(HaveOccurred())
})
```