### PR TITLE
Proper unmarshalling of k8s manifests with only JSON tags to YAML

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -10,7 +10,7 @@ keep_environments: Never # Options: Always, OnFail, Never
 apps:
     chainlink:
         image: public.ecr.aws/chainlink/chainlink
-        version: 0.10.10
+        version: 0.10.11
 
 private_keys: &private_keys
     private_keys:

--- a/environment/k8s_environment.go
+++ b/environment/k8s_environment.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/ghodss/yaml"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -17,11 +18,9 @@ import (
 
 	"github.com/avast/retry-go"
 	"github.com/hashicorp/go-multierror"
-	"github.com/smartcontractkit/integrations-framework/config"
-	"gopkg.in/yaml.v2"
-
 	"github.com/rs/zerolog/log"
 	"github.com/smartcontractkit/integrations-framework/client"
+	"github.com/smartcontractkit/integrations-framework/config"
 	appsV1 "k8s.io/api/apps/v1"
 	coreV1 "k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/environment/templates/adapter-deployment.yml
+++ b/environment/templates/adapter-deployment.yml
@@ -1,23 +1,21 @@
-objectmeta:
+metadata:
   name: dummy-adapter
 spec:
   selector:
     matchlabels:
       app: dummy-adapter
   template:
-    objectmeta:
+    metadata:
       labels:
         app: dummy-adapter
     spec:
       containers:
-      - name: dummy-adapter
-        image: kalverra/dummy-external-adapter
-        ports:
-        - containerport: {{ .Values.chainlinkCluster.adapter.apiPort }}
-        readinessprobe:
-          handler:
-            httpget:
+        - name: dummy-adapter
+          image: kalverra/dummy-external-adapter
+          ports:
+            - containerPort: {{ .Values.chainlinkCluster.adapter.apiPort }}
+          readinessProbe:
+            httpGet:
               path: /
-              port:
-                intval: 6060
-          periodseconds: 2
+              port: 6060
+            periodSeconds: 2

--- a/environment/templates/adapter-service.yml
+++ b/environment/templates/adapter-service.yml
@@ -1,11 +1,10 @@
-objectmeta:
+metadata:
   name: dummy-adapter
 spec:
   ports:
-  - name: access
-    port: {{ .Values.chainlinkCluster.adapter.apiPort }}
-    targetport:
-      intval: {{ .Values.chainlinkCluster.adapter.apiPort }}
+    - name: access
+      port: {{ .Values.chainlinkCluster.adapter.apiPort }}
+      targetPort: {{ .Values.chainlinkCluster.adapter.apiPort }}
   selector:
     app: dummy-adapter
   type: ClusterIP

--- a/environment/templates/chainlink-deployment.yml
+++ b/environment/templates/chainlink-deployment.yml
@@ -1,13 +1,12 @@
-objectmeta:
-  generatename: chainlink-node-
+metadata:
+  generateName: chainlink-node-
 spec:
   template:
     spec:
       volumes:
       - name: node-secrets-volume
-        volumesource:
-          secret:
-            secretname: {{ .Manifest.Secret.ObjectMeta.Name }}
+        secret:
+          secretName: {{ .Manifest.Secret.ObjectMeta.Name }}
       containers:
       - name: node
         image: {{ .Config.Apps.Chainlink.Image }}:{{ .Config.Apps.Chainlink.Version }}
@@ -22,115 +21,84 @@ spec:
         - --vrfpassword=/etc/node-secrets-volume/apicredentials
         ports:
         - name: access
-          containerport: {{ .Values.chainlinkCluster.chainlink.webPort }}
+          containerPort: {{ .Values.chainlinkCluster.chainlink.webPort }}
         - name: p2p
-          containerport: {{ .Values.chainlinkCluster.chainlink.p2pPort }}
+          containerPort: {{ .Values.chainlinkCluster.chainlink.p2pPort }}
         env:
         - name: DATABASE_URL
           value: postgresql://postgres:node@127.0.0.1:5432/chainlink?sslmode=disable
-          valuefrom: null
         - name: DATABASE_NAME
           value: chainlink
-          valuefrom: null
         - name: ETH_URL
           value: {{ if .Values.evm.clusterURL }}{{ .Values.evm.clusterURL }}{{ else }}{{ .Network.URL }}{{ end }}
-          valuefrom: null
         - name: ETH_CHAIN_ID
           value: {{ .Network.ChainID }}
-          valuefrom: null
         - name: ALLOW_ORIGINS
           value: '*'
-          valuefrom: null
         - name: CHAINLINK_DEV
           value: "true"
-          valuefrom: null
         - name: CHAINLINK_PGPASSWORD
           value: node
-          valuefrom: null
         - name: CHAINLINK_PORT
           value: "6688"
-          valuefrom: null
         - name: CHAINLINK_TLS_PORT
           value: "0"
-          valuefrom: null
         - name: DEFAULT_HTTP_ALLOW_UNRESTRICTED_NETWORK_ACCESS
           value: "true"
-          valuefrom: null
         - name: ENABLE_BULLETPROOF_TX_MANAGER
           value: "true"
-          valuefrom: null
         - name: FEATURE_OFFCHAIN_REPORTING
           value: "true"
-          valuefrom: null
         - name: JSON_CONSOLE
           value: "false"
-          valuefrom: null
         - name: LOG_LEVEL
           value: info
-          valuefrom: null
         - name: MAX_EXPORT_HTML_THREADS
           value: "2"
-          valuefrom: null
         - name: MINIMUM_CONTRACT_PAYMENT
           value: "0"
-          valuefrom: null
         - name: OCR_TRACE_LOGGING
           value: "true"
-          valuefrom: null
         - name: P2P_LISTEN_IP
           value: 0.0.0.0
-          valuefrom: null
         - name: P2P_LISTEN_PORT
           value: "6690"
-          valuefrom: null
         - name: ROOT
           value: ./clroot
-          valuefrom: null
         - name: SECURE_COOKIES
           value: "false"
-          valuefrom: null
         # keeper https://github.com/smartcontractkit/chainlink/wiki/How-to-Run-Keeper-Jobs
         - name: KEEPER_DEFAULT_TRANSACTION_QUEUE_DEPTH
           value: "1"
-          valuefrom: null
         - name: KEEPER_REGISTRY_SYNC_INTERVAL
           value: "5s"
-          valuefrom: null
         - name: KEEPER_MINIMUM_REQUIRED_CONFIRMATIONS
           value: "1"
-          valuefrom: null
         - name: KEEPER_MINIMUM_REQUIRED_CONFIRMATIONS
           value: "200000"
-          valuefrom: null
         - name: KEEPER_REGISTRY_PERFORM_GAS_OVERHEAD
           value: "150000"
-          valuefrom: null
-        volumemounts:
+        volumeMounts:
         - name: node-secrets-volume
           readonly: false
-          mountpath: /etc/node-secrets-volume/
-        livenessprobe:
-          handler:
-            exec: null
-            httpget:
-              path: /
-              port:
-                intval: {{ .Values.chainlinkCluster.chainlink.webPort }}
-          initialdelayseconds: 90
-          periodseconds: 10
-        readinessprobe:
-          handler:
-            httpget:
-              path: /
-              port:
-                intval: {{ .Values.chainlinkCluster.chainlink.webPort }}
-          initialdelayseconds: 2
-          periodseconds: 2
+          mountPath: /etc/node-secrets-volume/
+        livenessProbe:
+          httpGet:
+            path: /
+            port: {{ .Values.chainlinkCluster.chainlink.webPort }}
+          initialDelaySeconds: 90
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /
+            port: {{ .Values.chainlinkCluster.chainlink.webPort }}
+          initialDelaySeconds: 2
+          periodSeconds: 2
       - name: db
         image: postgres:11.6
         ports:
         - name: postgres
-          containerport: 5432
+          containerPort: 5432
         env:
         - name: POSTGRES_DB
           value: chainlink
@@ -145,20 +113,18 @@ spec:
           value: postgres
           valuefrom: null
         livenessprobe:
-          handler:
-            exec:
-              command:
+          exec:
+            command:
               - pg_isready
               - -U
               - postgres
-          initialdelayseconds: 60
-          periodseconds: 60
-        readinessprobe:
-          handler:
-            exec:
-              command:
+          initialDelaySeconds: 60
+          periodSeconds: 60
+        readinessProbe:
+          exec:
+            command:
               - pg_isready
               - -U
               - postgres
-          initialdelayseconds: 2
-          periodseconds: 2
+          initialDelaySeconds: 2
+          periodSeconds: 2

--- a/environment/templates/chainlink-service.yml
+++ b/environment/templates/chainlink-service.yml
@@ -1,15 +1,13 @@
-objectmeta:
-  generatename: chainlink-
+metadata:
+  generateName: chainlink-
 spec:
   ports:
   - name: node-port
     port: {{ .Values.chainlinkCluster.chainlink.webPort }}
-    targetport:
-      intval: {{ .Values.chainlinkCluster.chainlink.webPort }}
+    targetPort: {{ .Values.chainlinkCluster.chainlink.webPort }}
   - name: p2p-port
     port: {{ .Values.chainlinkCluster.chainlink.p2pPort }}
-    targetport:
-      intval: {{ .Values.chainlinkCluster.chainlink.p2pPort }}
+    targetPort: {{ .Values.chainlinkCluster.chainlink.p2pPort }}
   selector:
     app: chainlink-node
   type: ClusterIP

--- a/environment/templates/ganache-deployment.yml
+++ b/environment/templates/ganache-deployment.yml
@@ -1,8 +1,8 @@
-objectmeta:
+metadata:
   name: ganache
 spec:
   template:
-    objectmeta:
+    metadata:
       labels:
         app: ganache-network
     spec:
@@ -10,7 +10,7 @@ spec:
       - name: ganache-network
         image: trufflesuite/ganache-cli:v6.12.2
         ports:
-        - containerport: {{ .Values.evm.rpcPort }}
+        - containerPort: {{ .Values.evm.rpcPort }}
         args:
           - --account "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80,100000000000000000000"
           - --account "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d,100000000000000000000"

--- a/environment/templates/ganache-service.yml
+++ b/environment/templates/ganache-service.yml
@@ -1,11 +1,10 @@
-objectmeta:
+metadata:
   name: ganache-network
 spec:
   ports:
   - name: access
     port: {{ .Values.evm.rpcPort }}
-    targetport:
-      intval: {{ .Values.evm.rpcPort }}
+    targetPort: {{ .Values.evm.rpcPort }}
   selector:
     app: ganache-network
   type: ClusterIP

--- a/environment/templates/geth-config-map.yml
+++ b/environment/templates/geth-config-map.yml
@@ -2,8 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: gdmap
-objectmeta:
-  name: gdmap
 data:
   key1: |
     {"address":"f39fd6e51aad88f6f4ce6ab8827279cfffb92266","crypto":{"cipher":"aes-128-ctr","ciphertext":"c36afd6e60b82d6844530bd6ab44dbc3b85a53e826c3a7f6fc6a75ce38c1e4c6","cipherparams":{"iv":"f69d2bb8cd0cb6274535656553b61806"},"kdf":"scrypt","kdfparams":{"dklen":32,"n":262144,"p":1,"r":8,"salt":"80d5f5e38ba175b6b89acfc8ea62a6f163970504af301292377ff7baafedab53"},"mac":"f2ecec2c4d05aacc10eba5235354c2fcc3776824f81ec6de98022f704efbf065"},"id":"e5c124e9-e280-4b10-a27b-d7f3e516b408","version":3}

--- a/environment/templates/geth-deployment.yml
+++ b/environment/templates/geth-deployment.yml
@@ -1,81 +1,79 @@
-objectmeta:
+metadata:
   name: geth-dev-network
 spec:
   template:
     spec:
       volumes:
       - name: geth-configmap-volume
-        volumesource:
-          configmap:
-            localobjectreference:
-              name: gdmap
+        configMap:
+          name: gdmap
       containers:
       - name: geth-network
         image: ethereum/client-go:v1.10.3
         entrypoint: sh ./root/init.sh
-        volumemounts:
+        volumeMounts:
         - name: geth-configmap-volume
-          mountpath: /root/config
+          mountPath: /root/config
         - name: geth-configmap-volume
-          mountpath: /root/.ethereum/devchain/keystore/key1
-          subpath: key1
+          mountPath: /root/.ethereum/devchain/keystore/key1
+          subPath: key1
         - name: geth-configmap-volume
-          mountpath: /root/.ethereum/devchain/keystore/key2
-          subpath: key2
+          mountPath: /root/.ethereum/devchain/keystore/key2
+          subPath: key2
         - name: geth-configmap-volume
-          mountpath: /root/.ethereum/devchain/keystore/key3
-          subpath: key3
+          mountPath: /root/.ethereum/devchain/keystore/key3
+          subPath: key3
         - name: geth-configmap-volume
-          mountpath: /root/.ethereum/devchain/keystore/key4
-          subpath: key4
+          mountPath: /root/.ethereum/devchain/keystore/key4
+          subPath: key4
         - name: geth-configmap-volume
-          mountpath: /root/.ethereum/devchain/keystore/key5
-          subpath: key5
+          mountPath: /root/.ethereum/devchain/keystore/key5
+          subPath: key5
         - name: geth-configmap-volume
-          mountpath: /root/.ethereum/devchain/keystore/key6
-          subpath: key6
+          mountPath: /root/.ethereum/devchain/keystore/key6
+          subPath: key6
         - name: geth-configmap-volume
-          mountpath: /root/.ethereum/devchain/keystore/key7
-          subpath: key7
+          mountPath: /root/.ethereum/devchain/keystore/key7
+          subPath: key7
         - name: geth-configmap-volume
-          mountpath: /root/.ethereum/devchain/keystore/key8
-          subpath: key8
+          mountPath: /root/.ethereum/devchain/keystore/key8
+          subPath: key8
         - name: geth-configmap-volume
-          mountpath: /root/.ethereum/devchain/keystore/key9
-          subpath: key9
+          mountPath: /root/.ethereum/devchain/keystore/key9
+          subPath: key9
         - name: geth-configmap-volume
-          mountpath: /root/.ethereum/devchain/keystore/key10
-          subpath: key10
+          mountPath: /root/.ethereum/devchain/keystore/key10
+          subPath: key10
         - name: geth-configmap-volume
-          mountpath: /root/.ethereum/devchain/keystore/key11
-          subpath: key11
+          mountPath: /root/.ethereum/devchain/keystore/key11
+          subPath: key11
         - name: geth-configmap-volume
-          mountpath: /root/.ethereum/devchain/keystore/key12
-          subpath: key12
+          mountPath: /root/.ethereum/devchain/keystore/key12
+          subPath: key12
         - name: geth-configmap-volume
-          mountpath: /root/.ethereum/devchain/keystore/key13
-          subpath: key13
+          mountPath: /root/.ethereum/devchain/keystore/key13
+          subPath: key13
         - name: geth-configmap-volume
-          mountpath: /root/.ethereum/devchain/keystore/key14
-          subpath: key14
+          mountPath: /root/.ethereum/devchain/keystore/key14
+          subPath: key14
         - name: geth-configmap-volume
-          mountpath: /root/.ethereum/devchain/keystore/key15
-          subpath: key15
+          mountPath: /root/.ethereum/devchain/keystore/key15
+          subPath: key15
         - name: geth-configmap-volume
-          mountpath: /root/.ethereum/devchain/keystore/key16
-          subpath: key16
+          mountPath: /root/.ethereum/devchain/keystore/key16
+          subPath: key16
         - name: geth-configmap-volume
-          mountpath: /root/.ethereum/devchain/keystore/key17
-          subpath: key17
+          mountPath: /root/.ethereum/devchain/keystore/key17
+          subPath: key17
         - name: geth-configmap-volume
-          mountpath: /root/.ethereum/devchain/keystore/key18
-          subpath: key18
+          mountPath: /root/.ethereum/devchain/keystore/key18
+          subPath: key18
         - name: geth-configmap-volume
-          mountpath: /root/.ethereum/devchain/keystore/key19
-          subpath: key19
+          mountPath: /root/.ethereum/devchain/keystore/key19
+          subPath: key19
         - name: geth-configmap-volume
-          mountpath: /root/.ethereum/devchain/keystore/key20
-          subpath: key20
+          mountPath: /root/.ethereum/devchain/keystore/key20
+          subPath: key20
         args:
           - --dev
           - --dev.period
@@ -153,4 +151,4 @@ spec:
           - "*"
           - --vmdebug
         ports:
-        - containerport: {{ .Values.evm.rpcPort }}
+        - containerPort: {{ .Values.evm.rpcPort }}

--- a/environment/templates/geth-service.yml
+++ b/environment/templates/geth-service.yml
@@ -1,11 +1,10 @@
-objectmeta:
+metadata:
   name: geth-dev-network
 spec:
   ports:
   - name: access
     port: {{ .Values.evm.rpcPort }}
-    targetport:
-      intval: {{ .Values.evm.rpcPort }}
+    targetPort: {{ .Values.evm.rpcPort }}
   selector:
     app: geth-dev-network
   type: ClusterIP

--- a/environment/templates/hardhat-deployment.yml
+++ b/environment/templates/hardhat-deployment.yml
@@ -1,8 +1,8 @@
-objectmeta:
+metadata:
   name: hardhat-network
 spec:
   template:
-    objectmeta:
+    metadata:
       labels:
         app: hardhat-network
     spec:
@@ -10,12 +10,9 @@ spec:
       - name: hardhat-network
         image: smartcontract/hardhat-network
         ports:
-        - containerport: {{ .Values.evm.rpcPort }}
-        readinessprobe:
-          handler:
-            exec: null
-            httpget:
-              path: /
-              port:
-                intval: {{ .Values.evm.rpcPort }}
-          periodseconds: 2
+        - containerPort: {{ .Values.evm.rpcPort }}
+        readinessProbe:
+          httpGet:
+            path: /
+            port: { { .Values.evm.rpcPort } }
+          periodSeconds: 2

--- a/environment/templates/hardhat-service.yml
+++ b/environment/templates/hardhat-service.yml
@@ -1,11 +1,10 @@
-objectmeta:
+metadata:
   name: hardhat-network
 spec:
   ports:
   - name: access
     port: {{ .Values.evm.rpcPort }}
-    targetport:
-      intval: {{ .Values.evm.rpcPort }}
+    targetPort: {{ .Values.evm.rpcPort }}
   selector:
     app: hardhat-network
   type: ClusterIP

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/ethereum/go-ethereum v1.10.4
+	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/google/uuid v1.2.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/onsi/ginkgo v1.16.4

--- a/go.sum
+++ b/go.sum
@@ -303,6 +303,7 @@ github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff/go.mod h1:x
 github.com/gballet/go-libpcsclite v0.0.0-20191108122812-4678299bea08 h1:f6D9Hr8xV8uYKlyuj8XIruxlh9WjVjdh1gIicAS7ays=
 github.com/gballet/go-libpcsclite v0.0.0-20191108122812-4678299bea08/go.mod h1:x7DCsMOv1taUwEWCzT4cmDeAkigA5/QCwUodaVOe8Ww=
 github.com/gedex/inflector v0.0.0-20170307190818-16278e9db813/go.mod h1:P+oSoE9yhSRvsmYyZsshflcR6ePWYLql6UU1amW13IM=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/cors v1.3.1/go.mod h1:jjEJ4268OPZUcU7k9Pm653S7lXUGcqMADzFA61xsmDk=
 github.com/gin-contrib/expvar v0.0.0-20181230111036-f23b556cc79f/go.mod h1:lKdjvm96uBFqhKVjrNmDm66m199oRiOxJAThyr6rdW8=


### PR DESCRIPTION
Looking into issue https://github.com/kubernetes/client-go/issues/193 I've replaced our YAML library to https://github.com/ghodss/yaml so it can parse manifests properly even without YAML tags, so we don't need to reverse Go structs when we want to add something, and just code accordingly to k8s docs.