### PR TITLE
Add ability for tests to specify different network defaults

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -21,8 +21,8 @@ const (
 
 // Config is the overall config for the framework, holding configurations for supported networks
 type Config struct {
-	Logging            *LoggingConfig            `mapstructure:"logging" yaml:"logging"`
 	Network            string                    `mapstructure:"network" yaml:"network"`
+	Logging            *LoggingConfig            `mapstructure:"logging" yaml:"logging"`
 	Networks           map[string]*NetworkConfig `mapstructure:"networks" yaml:"networks"`
 	Retry              *RetryConfig              `mapstructure:"retry" yaml:"retry"`
 	Apps               AppConfig                 `mapstructure:"apps" yaml:"apps"`

--- a/suite/performance/flux_test.go
+++ b/suite/performance/flux_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Performance tests", func() {
 		By("Deploying the environment", func() {
 			s, err = actions.DefaultLocalSetup(
 				environment.NewChainlinkCluster(numberOfNodes),
-				client.NewNetworkFromConfig,
+				client.NewNetworkFromConfigWithDefault(client.NetworkGethPerformance),
 				tools.ProjectRoot,
 			)
 			Expect(err).ShouldNot(HaveOccurred())


### PR DESCRIPTION
This is needed for when we run the suite with defaults, as the performance test needs a different network with higher timeouts and higher block gas limits.