### PR TITLE
telemetry down alert tests

### DIFF
--- a/environment/environment.go
+++ b/environment/environment.go
@@ -57,6 +57,15 @@ func GetExplorerClientFromEnv(env Environment) (*client.ExplorerClient, error) {
 	return NewExplorerClient(sd.LocalURL.String())
 }
 
+// GetPrometheusClientFromEnv returns a Prometheus client
+func GetPrometheusClientFromEnv(env Environment) (*client.Prometheus, error) {
+	sd, err := env.GetServiceDetails(PrometheusAPIPort)
+	if err != nil {
+		return nil, err
+	}
+	return client.NewPrometheusClient(sd.LocalURL.String())
+}
+
 // GetChainlinkClients will return all instantiated Chainlink clients for a given environment
 func GetChainlinkClients(env Environment) ([]client.Chainlink, error) {
 	var clients []client.Chainlink

--- a/environment/environment_templates.go
+++ b/environment/environment_templates.go
@@ -20,12 +20,13 @@ import (
 
 // Ports for common services
 const (
-	AdapterAPIPort   = 6060
-	ChainlinkWebPort = 6688
-	ChainlinkP2PPort = 6690
-	EVMRPCPort       = 8545
-	MinersRPCPort    = 9545
-	ExplorerAPIPort  = 8080
+	AdapterAPIPort    = 6060
+	ChainlinkWebPort  = 6688
+	ChainlinkP2PPort  = 6690
+	EVMRPCPort        = 8545
+	MinersRPCPort     = 9545
+	ExplorerAPIPort   = 8080
+	PrometheusAPIPort = 9090
 )
 
 // NewAdapterManifest is the k8s manifest that when used will deploy an external adapter to an environment
@@ -536,7 +537,7 @@ func PrometheusGroup() K8sEnvSpecInit {
 	return func(config *config.NetworkConfig) (string, K8sEnvSpecs) {
 		var specs K8sEnvSpecs
 		prometheusDependencyGroup := &K8sManifestGroup{
-			id: "PrometheusDependencyGroup",
+			id:        "PrometheusDependencyGroup",
 			manifests: []K8sEnvResource{NewPrometheusManifest()},
 		}
 		specs = append(specs, prometheusDependencyGroup)

--- a/environment/templates/prometheus/rules/ocr.rules.yml
+++ b/environment/templates/prometheus/rules/ocr.rules.yml
@@ -19,7 +19,7 @@
             expr: (rate (sum:ocr_telemetry_ingested_total[1m])) == bool 0
           - alert: Telemetry Down (infra)
             expr: bool:telemetry_down == 1
-            for: 5m
+            for: 1m
             labels:
               severity: critical
               team: infra
@@ -28,7 +28,7 @@
 
           - alert: Telemetry Down (o11y)
             expr: bool:telemetry_down == 1
-            for: 5m
+            for: 1m
             labels:
               severity: critical
               team: monitoring

--- a/suite/alerts/alerts_test.go
+++ b/suite/alerts/alerts_test.go
@@ -1,26 +1,107 @@
 package alerts
 
 import (
+	"context"
+	"fmt"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+	"github.com/smartcontractkit/integrations-framework/chaos"
+	"github.com/smartcontractkit/integrations-framework/chaos/experiments"
 	"github.com/smartcontractkit/integrations-framework/environment"
+	"github.com/smartcontractkit/integrations-framework/suite/steps"
 	"github.com/smartcontractkit/integrations-framework/suite/testcommon"
 )
 
-var _ = Describe("Alerts suite", func() {
-	Describe("Alerts", func() {
-		It("Deploys the alerts stack up to Prometheus", func() {
-			i := &testcommon.OCRSetupInputs{}
-			testcommon.DeployOCRForEnv(i, "basic-chainlink", environment.NewChainlinkClusterForAlertsTesting(5))
-			testcommon.SetupOCRTest(i)
-			testcommon.CheckRound(i)
-			testcommon.WriteDataForOTPEToInitializerFileForMockserver(i)
+var _ = Describe("OCR Alerts suite", func() {
+	var (
+		testSetup *testcommon.OCRSetupInputs
+	)
 
-			err := i.SuiteSetup.Env.DeploySpecs(environment.OtpeGroup())
+	BeforeEach(func() {
+		By("Deploying the basic environment", func() {
+			testSetup = &testcommon.OCRSetupInputs{}
+			testcommon.DeployOCRForEnv(
+				testSetup,
+				"basic-chainlink",
+				environment.NewChainlinkClusterForAlertsTesting(6),
+			)
+			testcommon.SetupOCRTest(testSetup)
+		})
+
+		By("Creating initializer file for mockserver", func() {
+			steps.WriteDataForOTPEToInitializerFileForMockserver(
+				testSetup.OCRInstance.Address(),
+				testSetup.ChainlinkNodes,
+			)
+		})
+
+		By("Deploying otpe and prometheus", func() {
+			err := testSetup.SuiteSetup.Env.DeploySpecs(environment.OtpeGroup())
 			Expect(err).ShouldNot(HaveOccurred())
 
-			err = i.SuiteSetup.Env.DeploySpecs(environment.PrometheusGroup())
+			err = testSetup.SuiteSetup.Env.DeploySpecs(environment.PrometheusGroup())
 			Expect(err).ShouldNot(HaveOccurred())
 		})
+	})
+
+	Describe("Telemetry Down Alerts", func() {
+		It("Doesn't start the OCR protocol", func() {
+			prometheus, err := environment.GetPrometheusClientFromEnv(testSetup.SuiteSetup.Env)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			Eventually(func(g Gomega) []v1.Alert {
+				alerts, err := prometheus.Alerts(context.Background())
+				g.Expect(err).ShouldNot(HaveOccurred())
+				return alerts.Alerts
+			}, "5m", "15s").Should(ContainElement(MatchFields(IgnoreExtras, Fields{
+				"Labels": MatchKeys(IgnoreExtras, Keys{
+					model.LabelName("alertname"): Equal(model.LabelValue("Telemetry Down (infra)")),
+				}),
+				"State": Equal(v1.AlertState("firing")),
+			})))
+		})
+
+		It("Shuts down all chainlink nodes after some successful rounds", func() {
+			testcommon.SendOcrJobs(testSetup)
+			testcommon.CheckRound(testSetup)
+
+			experimentSpecs := make([]chaos.Experimentable, len(testSetup.ChainlinkNodes[1:]))
+
+			for i := 0; i < len(testSetup.ChainlinkNodes[1:]); i++ {
+				experimentSpecs[i] = &experiments.PodKill{
+					TargetAppLabel: fmt.Sprintf("chainlink-%d", i+1),
+				}
+			}
+
+			for _, experimentSpec := range experimentSpecs {
+				_, err := testSetup.SuiteSetup.Env.ApplyChaos(experimentSpec)
+				Expect(err).ShouldNot(HaveOccurred())
+			}
+
+			prometheus, err := environment.GetPrometheusClientFromEnv(testSetup.SuiteSetup.Env)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			Eventually(func(g Gomega) []v1.Alert {
+				alerts, err := prometheus.Alerts(context.Background())
+				g.Expect(err).ShouldNot(HaveOccurred())
+				return alerts.Alerts
+			}, "5m", "15s").Should(ContainElement(MatchFields(IgnoreExtras, Fields{
+				"Labels": MatchKeys(IgnoreExtras, Keys{
+					model.LabelName("alertname"): Equal(model.LabelValue("Telemetry Down (infra)")),
+				}),
+				"State": Equal(v1.AlertState("firing")),
+			})))
+		})
+	})
+
+	AfterEach(func() {
+		By("Restoring chaos", func() {
+			err := testSetup.SuiteSetup.Env.StopAllChaos()
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+		By("Tearing down the environment", testSetup.SuiteSetup.TearDown())
 	})
 })

--- a/suite/alerts/alerts_test.go
+++ b/suite/alerts/alerts_test.go
@@ -65,7 +65,7 @@ var _ = Describe("OCR Alerts suite", func() {
 		})
 
 		It("Shuts down all chainlink nodes after some successful rounds", func() {
-			testcommon.SendOcrJobs(testSetup)
+			testcommon.SendOCRJobs(testSetup)
 			testcommon.CheckRound(testSetup)
 
 			experimentSpecs := make([]chaos.Experimentable, len(testSetup.ChainlinkNodes[1:]))

--- a/suite/alerts/alerts_test.go
+++ b/suite/alerts/alerts_test.go
@@ -98,7 +98,7 @@ var _ = Describe("OCR Alerts suite", func() {
 	})
 
 	AfterEach(func() {
-		By("Restoring chaos", func() {
+		By("Stop chaos", func() {
 			err := testSetup.SuiteSetup.Env.StopAllChaos()
 			Expect(err).ShouldNot(HaveOccurred())
 		})

--- a/suite/chaos/chaos_ocr_test.go
+++ b/suite/chaos/chaos_ocr_test.go
@@ -20,6 +20,7 @@ var _ = XDescribeTable("OCR chaos tests @chaos-ocr", func(
 	Context("Runs OCR test with a chaos modifier", func() {
 		testcommon.DeployOCRForEnv(i, envName, envInit)
 		testcommon.SetupOCRTest(i)
+		testcommon.SendOcrJobs(i)
 		_, err := i.SuiteSetup.Env.ApplyChaos(chaosSpec)
 		Expect(err).ShouldNot(HaveOccurred())
 		testcommon.CheckRound(i)
@@ -34,7 +35,7 @@ var _ = XDescribeTable("OCR chaos tests @chaos-ocr", func(
 },
 	Entry("One node pod failure",
 		"basic-chainlink",
-		environment.NewChainlinkCluster(5),
+		environment.NewChainlinkCluster(6),
 		&experiments.PodFailure{
 			LabelKey:   "app",
 			LabelValue: "chainlink-0",

--- a/suite/chaos/chaos_ocr_test.go
+++ b/suite/chaos/chaos_ocr_test.go
@@ -20,7 +20,7 @@ var _ = XDescribeTable("OCR chaos tests @chaos-ocr", func(
 	Context("Runs OCR test with a chaos modifier", func() {
 		testcommon.DeployOCRForEnv(i, envName, envInit)
 		testcommon.SetupOCRTest(i)
-		testcommon.SendOcrJobs(i)
+		testcommon.SendOCRJobs(i)
 		_, err := i.SuiteSetup.Env.ApplyChaos(chaosSpec)
 		Expect(err).ShouldNot(HaveOccurred())
 		testcommon.CheckRound(i)

--- a/suite/contracts/contracts_ocr_test.go
+++ b/suite/contracts/contracts_ocr_test.go
@@ -16,7 +16,7 @@ var _ = Describe("OCR Feed @ocr", func() {
 		i := &testcommon.OCRSetupInputs{}
 		testcommon.DeployOCRForEnv(i, envName, envInit)
 		testcommon.SetupOCRTest(i)
-		testcommon.SendOcrJobs(i)
+		testcommon.SendOCRJobs(i)
 		testcommon.CheckRound(i)
 		By("Printing gas stats", func() {
 			i.SuiteSetup.Client.GasStats().PrintStats()

--- a/suite/contracts/contracts_ocr_test.go
+++ b/suite/contracts/contracts_ocr_test.go
@@ -16,13 +16,14 @@ var _ = Describe("OCR Feed @ocr", func() {
 		i := &testcommon.OCRSetupInputs{}
 		testcommon.DeployOCRForEnv(i, envName, envInit)
 		testcommon.SetupOCRTest(i)
+		testcommon.SendOcrJobs(i)
 		testcommon.CheckRound(i)
 		By("Printing gas stats", func() {
 			i.SuiteSetup.Client.GasStats().PrintStats()
 		})
 		By("Tearing down the environment", i.SuiteSetup.TearDown())
 	},
-		Entry("all the same version", "basic-chainlink", environment.NewChainlinkCluster(5)),
-		Entry("different versions", "mixed-version-chainlink", environment.NewMixedVersionChainlinkCluster(5, 2)),
+		Entry("all the same version", "basic-chainlink", environment.NewChainlinkCluster(6)),
+		Entry("different versions", "mixed-version-chainlink", environment.NewMixedVersionChainlinkCluster(6, 2)),
 	)
 })

--- a/suite/steps/alerts_steps.go
+++ b/suite/steps/alerts_steps.go
@@ -1,0 +1,60 @@
+package steps
+
+import (
+	"encoding/json"
+	. "github.com/onsi/gomega"
+	"github.com/smartcontractkit/integrations-framework/client"
+	"github.com/smartcontractkit/integrations-framework/environment/charts/mockserver"
+	"github.com/smartcontractkit/integrations-framework/tools"
+	"os"
+	"path/filepath"
+)
+
+// WriteDataForOTPEToInitializerFileForMockserver Write to initializerJson mocked weiwatchers data needed for otpe
+func WriteDataForOTPEToInitializerFileForMockserver(offChainAggregatorInstanceAddress string, chainlinkNodes []client.Chainlink) {
+	contractInfo := mockserver.ContractInfoJSON{
+		ContractVersion: 4,
+		Path:            "test",
+		Status:          "live",
+		ContractAddress: offChainAggregatorInstanceAddress,
+	}
+
+	contractsInfo := []mockserver.ContractInfoJSON{contractInfo}
+
+	contractsInitializer := mockserver.HttpInitializer{
+		Request:  mockserver.HttpRequest{Path: "/contracts.json"},
+		Response: mockserver.HttpResponse{Body: contractsInfo},
+	}
+
+	var nodesInfo []mockserver.NodeInfoJSON
+
+	for _, chainlink := range chainlinkNodes {
+		ocrKeys, err := chainlink.ReadOCRKeys()
+		Expect(err).ShouldNot(HaveOccurred())
+		nodeInfo := mockserver.NodeInfoJSON{
+			NodeAddress: []string{ocrKeys.Data[0].Attributes.OnChainSigningAddress},
+			ID:          ocrKeys.Data[0].ID,
+		}
+		nodesInfo = append(nodesInfo, nodeInfo)
+	}
+
+	nodesInitializer := mockserver.HttpInitializer{
+		Request:  mockserver.HttpRequest{Path: "/nodes.json"},
+		Response: mockserver.HttpResponse{Body: nodesInfo},
+	}
+	initializers := []mockserver.HttpInitializer{contractsInitializer, nodesInitializer}
+
+	initializersBytes, err := json.Marshal(initializers)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	fileName := filepath.Join(tools.ProjectRoot, "environment/charts/mockserver-config/static/initializerJson.json")
+	f, err := os.OpenFile(fileName, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	body := string(initializersBytes)
+	_, err = f.WriteString(body)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	err = f.Close()
+	Expect(err).ShouldNot(HaveOccurred())
+}

--- a/suite/testcommon/ocr.go
+++ b/suite/testcommon/ocr.go
@@ -2,12 +2,8 @@ package testcommon
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"github.com/smartcontractkit/integrations-framework/environment/charts/mockserver"
 	"math/big"
-	"os"
-	"path/filepath"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -70,8 +66,8 @@ func SetupOCRTest(i *OCRSetupInputs) {
 		Expect(err).ShouldNot(HaveOccurred())
 		err = i.OCRInstance.SetConfig(
 			i.DefaultWallet,
-			i.ChainlinkNodes,
-			contracts.DefaultOffChainAggregatorConfig(len(i.ChainlinkNodes)),
+			i.ChainlinkNodes[1:],
+			contracts.DefaultOffChainAggregatorConfig(len(i.ChainlinkNodes[1:])),
 		)
 		Expect(err).ShouldNot(HaveOccurred())
 		err = i.OCRInstance.Fund(i.DefaultWallet, nil, big.NewFloat(2))
@@ -79,7 +75,10 @@ func SetupOCRTest(i *OCRSetupInputs) {
 		err = i.SuiteSetup.Client.WaitForEvents()
 		Expect(err).ShouldNot(HaveOccurred())
 	})
+}
 
+// SendOcrJobs sends ocr jobs to chainlink nodes
+func SendOcrJobs(i *OCRSetupInputs) {
 	By("Sending OCR jobs to chainlink nodes", func() {
 		// Initialize bootstrap node
 		bootstrapNode := i.ChainlinkNodes[0]
@@ -165,53 +164,4 @@ func CheckRound(i *OCRSetupInputs) {
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(answer.Int64()).Should(Equal(int64(10)), "Latest answer from OCR is not as expected")
 	})
-}
-
-// WriteDataForOTPEToInitializerFileForMockserver Write to initializerJson mocked weiwatchers data needed for otpe
-func WriteDataForOTPEToInitializerFileForMockserver(i *OCRSetupInputs) {
-	contractInfo := mockserver.ContractInfoJSON{
-		ContractVersion: 4,
-		Path:            "test",
-		Status:          "live",
-		ContractAddress: i.OCRInstance.Address(),
-	}
-
-	contractsInfo := []mockserver.ContractInfoJSON{contractInfo}
-
-	contractsInitializer := mockserver.HttpInitializer{
-		Request:  mockserver.HttpRequest{Path: "/contracts.json"},
-		Response: mockserver.HttpResponse{Body: contractsInfo},
-	}
-
-	var nodesInfo []mockserver.NodeInfoJSON
-
-	for _, chainlink := range i.ChainlinkNodes {
-		ocrKeys, err := chainlink.ReadOCRKeys()
-		Expect(err).ShouldNot(HaveOccurred())
-		nodeInfo := mockserver.NodeInfoJSON{
-			NodeAddress: []string{ocrKeys.Data[0].Attributes.OnChainSigningAddress},
-			ID:          ocrKeys.Data[0].ID,
-		}
-		nodesInfo = append(nodesInfo, nodeInfo)
-	}
-
-	nodesInitializer := mockserver.HttpInitializer{
-		Request:  mockserver.HttpRequest{Path: "/nodes.json"},
-		Response: mockserver.HttpResponse{Body: nodesInfo},
-	}
-	initializers := []mockserver.HttpInitializer{contractsInitializer, nodesInitializer}
-
-	initializersBytes, err := json.Marshal(initializers)
-	Expect(err).ShouldNot(HaveOccurred())
-
-	fileName := filepath.Join(tools.ProjectRoot, "environment/charts/mockserver-config/static/initializerJson.json")
-	f, err := os.OpenFile(fileName, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
-	Expect(err).ShouldNot(HaveOccurred())
-
-	body := string(initializersBytes)
-	_, err = f.WriteString(body)
-	Expect(err).ShouldNot(HaveOccurred())
-
-	err = f.Close()
-	Expect(err).ShouldNot(HaveOccurred())
 }

--- a/suite/testcommon/ocr.go
+++ b/suite/testcommon/ocr.go
@@ -77,8 +77,8 @@ func SetupOCRTest(i *OCRSetupInputs) {
 	})
 }
 
-// SendOcrJobs sends ocr jobs to chainlink nodes
-func SendOcrJobs(i *OCRSetupInputs) {
+// SendOCRJobs sends ocr jobs to chainlink nodes
+func SendOCRJobs(i *OCRSetupInputs) {
 	By("Sending OCR jobs to chainlink nodes", func() {
 		// Initialize bootstrap node
 		bootstrapNode := i.ChainlinkNodes[0]


### PR DESCRIPTION
Added 2 tests for the Telemetry Down alert.
1. The alert is fired if the nodes are registered on the offchainAggregator contract but have not run any jobs related to OCR
2. The alert is fired if after some successful rounds all participating chainlink nodes shut down