### PR TITLE
Clean-up policy service for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,3 +95,7 @@ test_vrf: ## run vrf tests
 .PHONY: test_observability
 test_observability: # run observability tests
 	ginkgo -r --focus=@observability
+
+.PHONY: test_cleaner
+test_cleaner: ## run cleaner tests
+	ginkgo -r --focus=@cleaner

--- a/actions/setup.go
+++ b/actions/setup.go
@@ -37,6 +37,7 @@ type DefaultSuiteSetup struct {
 // DefaultLocalSetup setup minimum required components for test
 func DefaultLocalSetup(
 	envName string,
+	policyLabels map[string]string,
 	initialDeployInitFunc environment.K8sEnvSpecInit,
 	initFunc client.BlockchainNetworkInit,
 	configPath string,
@@ -50,7 +51,7 @@ func DefaultLocalSetup(
 		return nil, err
 	}
 
-	env, err := environment.NewK8sEnvironment(envName, conf, network)
+	env, err := environment.NewK8sEnvironment(envName, policyLabels, conf, network)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/cmd/create_env.go
+++ b/cli/cmd/create_env.go
@@ -45,7 +45,7 @@ func createRunE(cmd *cobra.Command, _ []string) error {
 	switch envType {
 	case "chainlink":
 		envSpec := environment.NewChainlinkCluster(nodes)
-		env, err = environment.NewK8sEnvironment("basic-chainlink", cfg, networkConfig)
+		env, err = environment.NewK8sEnvironment("basic-chainlink", nil, cfg, networkConfig)
 		if err != nil {
 			return err
 		}

--- a/environment/cleaner/README.md
+++ b/environment/cleaner/README.md
@@ -1,0 +1,16 @@
+### Env cleaner
+A tool to clean up stale test namespaces by applying different policies
+
+#### Usage
+Add some policy to apply for namespace, rebuild image
+```
+./update_image.sh
+```
+Run it inside the cluster
+```
+./start.sh
+./stop.sh
+```
+In order for service to work you need `clusterrolebinding` set to have `remove` verb, example:
+```
+kubectl create clusterrolebinding cleaner-delete-ns --clusterrole=${some_role_with_remove_access} --serviceaccount=default:default```

--- a/environment/cleaner/cleaner.go
+++ b/environment/cleaner/cleaner.go
@@ -1,0 +1,89 @@
+package cleaner
+
+import (
+	"context"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/smartcontractkit/integrations-framework/environment"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"os"
+	"time"
+)
+
+// NamespacePolicy arbitrary set of rules that can by applied to test namespaces
+type NamespacePolicy interface {
+	Apply() error
+	IsApplied() bool
+}
+
+func init() {
+	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
+}
+
+// Config cleaner service config
+type Config struct {
+	PollInterval time.Duration
+}
+
+// Cleaner cleaner service struct with a set of policies to apply
+type Cleaner struct {
+	cfg      *Config
+	client   *kubernetes.Clientset
+	policies map[string]NamespacePolicy
+}
+
+// NewCleaner creates new cleaner service
+func NewCleaner(client *kubernetes.Clientset, cfg *Config) *Cleaner {
+	return &Cleaner{
+		cfg:      cfg,
+		client:   client,
+		policies: map[string]NamespacePolicy{},
+	}
+}
+
+// updatePolicies gets all test namespaces marked by particular labels and create policies for a new one
+func (c *Cleaner) updatePolicies() error {
+	ns, err := c.client.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{
+		LabelSelector: environment.BasicTestNamespaceSelector,
+		FieldSelector: environment.NamespaceActivePhaseSelector,
+	})
+	if err != nil {
+		return err
+	}
+	for _, n := range ns.Items {
+		typ, ok := n.ObjectMeta.Labels["policy"]
+		if !ok {
+			log.Error().Str("Namespace", n.Name).Msg("No type label found on")
+			continue
+		}
+		switch typ {
+		case "timeout":
+			c.policies[n.Name] = &TimeoutPolicy{
+				Namespace: n,
+				client:    c.client,
+			}
+		}
+	}
+	return nil
+}
+
+// Run runs cleaner loop
+func (c *Cleaner) Run() error {
+	for {
+		if err := c.updatePolicies(); err != nil {
+			return err
+		}
+		for ns, policy := range c.policies {
+			if policy.IsApplied() {
+				delete(c.policies, ns)
+			}
+			if err := policy.Apply(); err != nil {
+				log.Err(err).Send()
+				return err
+			}
+		}
+		log.Debug().Int("Total", len(c.policies)).Msg("Total policies")
+		time.Sleep(c.cfg.PollInterval)
+	}
+}

--- a/environment/cleaner/cleaner_suite_test.go
+++ b/environment/cleaner/cleaner_suite_test.go
@@ -1,0 +1,19 @@
+package cleaner_test
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/reporters"
+	. "github.com/onsi/gomega"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+func TestCleaner(t *testing.T) {
+	RegisterFailHandler(Fail)
+	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
+	junitReporter := reporters.NewJUnitReporter("junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Environment Cleaner Suite", []Reporter{junitReporter})
+}

--- a/environment/cleaner/cleaner_test.go
+++ b/environment/cleaner/cleaner_test.go
@@ -1,0 +1,120 @@
+package cleaner
+
+import (
+	"context"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/smartcontractkit/integrations-framework/environment"
+	coreV1 "k8s.io/api/core/v1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"time"
+)
+
+func newNamespace(client *kubernetes.Clientset, labels map[string]string) (string, error) {
+	ns, err := client.CoreV1().Namespaces().Create(
+		context.Background(),
+		&coreV1.Namespace{
+			ObjectMeta: metaV1.ObjectMeta{
+				GenerateName: "something-",
+				Labels:       labels,
+			},
+		},
+		metaV1.CreateOptions{},
+	)
+	if err != nil {
+		return "", err
+	}
+	return ns.Name, err
+}
+
+func rmNamespace(client *kubernetes.Clientset, name string) error {
+	if err := client.CoreV1().Namespaces().Delete(context.Background(), name, metaV1.DeleteOptions{}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func newNamespaces(number int, client *kubernetes.Clientset, labels map[string]string) error {
+	for i := 0; i < number; i++ {
+		if _, err := client.CoreV1().Namespaces().Create(
+			context.Background(),
+			&coreV1.Namespace{
+				ObjectMeta: metaV1.ObjectMeta{
+					GenerateName: "something-",
+					Labels:       labels,
+				},
+			},
+			metaV1.CreateOptions{},
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func getNamespace(client *kubernetes.Clientset, name string) (*coreV1.Namespace, error) {
+	ns, err := client.CoreV1().Namespaces().Get(context.Background(), name, metaV1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return ns, nil
+}
+
+var _ = Describe("Environment Cleaner tests @cleaner", func() {
+	var (
+		clientset             *kubernetes.Clientset
+		notATestNamespaceName string
+		err                   error
+	)
+	Describe("Basic tests for timeout policy", func() {
+		It("Must delete only labelled namespaces after timeout", func() {
+			config, err := environment.K8sConfig()
+			Expect(err).ShouldNot(HaveOccurred())
+			clientset, err = kubernetes.NewForConfig(config)
+			Expect(err).ShouldNot(HaveOccurred())
+			c := NewCleaner(clientset, &Config{PollInterval: 1 * time.Second})
+			// nolint
+			go c.Run()
+			notATestNamespaceName, err = newNamespace(clientset, map[string]string{
+				"type": "not_a_test",
+			})
+			Expect(err).ShouldNot(HaveOccurred())
+			err = newNamespaces(3, clientset, map[string]string{
+				"type":    "test",
+				"policy":  "timeout",
+				"timeout": "3s",
+			})
+			Expect(err).ShouldNot(HaveOccurred())
+			err = newNamespaces(2, clientset, map[string]string{
+				"type":    "test",
+				"policy":  "timeout",
+				"timeout": "10s",
+			})
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(func(g Gomega) int {
+				ns, _ := clientset.CoreV1().Namespaces().List(context.Background(), metaV1.ListOptions{
+					LabelSelector: environment.BasicTestNamespaceSelector,
+				})
+				return len(ns.Items)
+			}, "20s", "1s").Should(Equal(2))
+			Eventually(func(g Gomega) int {
+				ns, _ := clientset.CoreV1().Namespaces().List(context.Background(), metaV1.ListOptions{
+					LabelSelector: environment.BasicTestNamespaceSelector,
+				})
+				return len(ns.Items)
+			}, "20s", "1s").Should(Equal(0))
+			ns, _ := clientset.CoreV1().Namespaces().List(context.Background(), metaV1.ListOptions{
+				LabelSelector: environment.BasicTestNamespaceSelector,
+			})
+			Expect(ns.Items).Should(HaveLen(0))
+			n, err := getNamespace(clientset, notATestNamespaceName)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(string(n.Status.Phase)).Should(Equal("Active"))
+		})
+		AfterEach(func() {
+			err = rmNamespace(clientset, notATestNamespaceName)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+	})
+})

--- a/environment/cleaner/cmd/Dockerfile
+++ b/environment/cleaner/cmd/Dockerfile
@@ -1,0 +1,3 @@
+FROM debian
+COPY app /app
+ENTRYPOINT /app

--- a/environment/cleaner/cmd/main.go
+++ b/environment/cleaner/cmd/main.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"github.com/rs/zerolog/log"
+	"github.com/smartcontractkit/integrations-framework/environment/cleaner"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"time"
+)
+
+func main() {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		log.Fatal().Err(err)
+	}
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		log.Fatal().Err(err)
+	}
+	c := cleaner.NewCleaner(clientset, &cleaner.Config{PollInterval: 30 * time.Second})
+	if err := c.Run(); err != nil {
+		log.Fatal().Err(err)
+	}
+}

--- a/environment/cleaner/cmd/start.sh
+++ b/environment/cleaner/cmd/start.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+kubectl run -i env-cleaner --image="${REGISTRY}"/env-cleaner

--- a/environment/cleaner/cmd/stop.sh
+++ b/environment/cleaner/cmd/stop.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+kubectl delete pod env-cleaner

--- a/environment/cleaner/cmd/update_image.sh
+++ b/environment/cleaner/cmd/update_image.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+GOOS=linux go build -o ./app . || exit 1;
+docker build -t env-cleaner .
+docker tag env-cleaner:latest "${REGISTRY}"/env-cleaner
+docker push "${REGISTRY}"/env-cleaner

--- a/environment/cleaner/policy.go
+++ b/environment/cleaner/policy.go
@@ -1,0 +1,54 @@
+package cleaner
+
+import (
+	"context"
+	"github.com/rs/zerolog/log"
+	v1 "k8s.io/api/core/v1"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"time"
+)
+
+// TimeoutPolicy struct for timeout policy for various e2e tests
+type TimeoutPolicy struct {
+	Namespace v1.Namespace
+	client    *kubernetes.Clientset
+	Applied   bool
+}
+
+// IsApplied checks if policy is already applied
+func (p *TimeoutPolicy) IsApplied() bool {
+	return p.Applied
+}
+
+// Apply removes namespace if timeout is reached
+func (p *TimeoutPolicy) Apply() error {
+	if p.Applied {
+		return nil
+	}
+	elapsed := time.Since(p.Namespace.CreationTimestamp.Time)
+	timeout, ok := p.Namespace.Labels["timeout"]
+	if !ok {
+		log.Warn().Str("Namespace", p.Namespace.Name).Msg("No timeout field found")
+		p.Applied = true
+		return nil
+	}
+	timeoutDur, err := time.ParseDuration(timeout)
+	if err != nil {
+		return err
+	}
+	canApply := elapsed > timeoutDur
+	log.Info().
+		Str("Namespace", p.Namespace.Name).
+		Str("Elapsed", elapsed.String()).
+		Bool("CanApply", canApply).
+		Msg("Watching test namespace")
+	if !canApply {
+		return nil
+	}
+	p.Applied = true
+	if err := p.client.CoreV1().Namespaces().Delete(context.Background(), p.Namespace.Name, v12.DeleteOptions{}); err != nil {
+		return err
+	}
+	return nil
+}

--- a/environment/environment_test.go
+++ b/environment/environment_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Environment unit tests @unit", func() {
 			bcNetwork, err := client.NewNetworkFromConfig(conf)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			env, err := environment.NewK8sEnvironment("basic-chainlink", conf, bcNetwork)
+			env, err := environment.NewK8sEnvironment("basic-chainlink", nil, conf, bcNetwork)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			err = env.DeploySpecs(environment.NewChainlinkCluster(1))

--- a/environment/k8s_environment_helm_test.go
+++ b/environment/k8s_environment_helm_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Environment with Helm @helm_deploy", func() {
 			conf.Network = "ethereum_geth_reorg"
 			networkConfig, err := client.NewNetworkFromConfig(conf)
 			Expect(err).ShouldNot(HaveOccurred())
-			env, err = NewK8sEnvironment("basic-chainlink", conf, networkConfig)
+			env, err = NewK8sEnvironment("basic-chainlink", nil, conf, networkConfig)
 			Expect(err).ShouldNot(HaveOccurred())
 			err = env.DeploySpecs(NewChainlinkCluster(1))
 			Expect(err).ShouldNot(HaveOccurred())

--- a/environment/k8s_environment_test.go
+++ b/environment/k8s_environment_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Environment functionality @unit", func() {
 		networkConfig, err := initFunc(conf)
 		Expect(err).ShouldNot(HaveOccurred())
 
-		env, err := NewK8sEnvironment("basic-chainlink", conf, networkConfig)
+		env, err := NewK8sEnvironment("basic-chainlink", nil, conf, networkConfig)
 		Expect(err).ShouldNot(HaveOccurred())
 		err = env.DeploySpecs(envInitFunc)
 		Expect(err).ShouldNot(HaveOccurred())

--- a/suite/contracts/contracts_cron_test.go
+++ b/suite/contracts/contracts_cron_test.go
@@ -23,6 +23,7 @@ var _ = Describe("Cronjob suite @cron", func() {
 		By("Deploying the environment", func() {
 			s, err = actions.DefaultLocalSetup(
 				"basic-chainlink",
+				nil,
 				environment.NewChainlinkCluster(1),
 				client.NewNetworkFromConfig,
 				tools.ProjectRoot,
@@ -53,7 +54,7 @@ var _ = Describe("Cronjob suite @cron", func() {
 
 	Describe("with Cron job", func() {
 		It("runs 5 times with no errors", func() {
-			Eventually(func(g Gomega){
+			Eventually(func(g Gomega) {
 				jobRuns, err := nodes[0].ReadRunsByJob(job.Data.ID)
 				g.Expect(err).ShouldNot(HaveOccurred())
 

--- a/suite/contracts/contracts_flux_test.go
+++ b/suite/contracts/contracts_flux_test.go
@@ -34,6 +34,7 @@ var _ = Describe("Flux monitor suite @flux", func() {
 		By("Deploying the environment", func() {
 			s, err = actions.DefaultLocalSetup(
 				"basic-chainlink",
+				nil,
 				environment.NewChainlinkCluster(3),
 				client.NewNetworkFromConfig,
 				tools.ProjectRoot,

--- a/suite/contracts/contracts_flux_validate_flag_test.go
+++ b/suite/contracts/contracts_flux_validate_flag_test.go
@@ -40,6 +40,7 @@ var _ = Describe("Flux monitor external validator suite @validator-flux", func()
 		By("Deploying the environment", func() {
 			s, err = actions.DefaultLocalSetup(
 				"basic-chainlink",
+				nil,
 				environment.NewChainlinkCluster(3),
 				client.NewNetworkFromConfig,
 				tools.ProjectRoot,

--- a/suite/contracts/contracts_keeper_test.go
+++ b/suite/contracts/contracts_keeper_test.go
@@ -30,6 +30,7 @@ var _ = Describe("Keeper suite @keeper", func() {
 		By("Deploying the environment", func() {
 			s, err = actions.DefaultLocalSetup(
 				"basic-chainlink",
+				nil,
 				// need to register at least 5 nodes to perform upkeep
 				environment.NewChainlinkCluster(5),
 				client.NewNetworkFromConfig,
@@ -147,7 +148,7 @@ var _ = Describe("Keeper suite @keeper", func() {
 	})
 	Describe("with Keeper job", func() {
 		It("performs upkeep of a target contract", func() {
-			Eventually(func(g Gomega){
+			Eventually(func(g Gomega) {
 				cnt, err := consumer.Counter(context.Background())
 				g.Expect(err).ShouldNot(HaveOccurred())
 				g.Expect(cnt.Int64()).Should(BeNumerically(">", 0))

--- a/suite/contracts/contracts_runlog_test.go
+++ b/suite/contracts/contracts_runlog_test.go
@@ -34,6 +34,7 @@ var _ = Describe("Direct request suite @runlog", func() {
 		By("Deploying the environment", func() {
 			s, err = actions.DefaultLocalSetup(
 				"basic-chainlink",
+				environment.BasicTestEnvLabelsMap,
 				environment.NewChainlinkCluster(1),
 				client.NewNetworkFromConfig,
 				tools.ProjectRoot,
@@ -113,7 +114,7 @@ var _ = Describe("Direct request suite @runlog", func() {
 
 	Describe("with DirectRequest job", func() {
 		It("receives API call data on-chain", func() {
-			Eventually(func(g Gomega){
+			Eventually(func(g Gomega) {
 				d, err := consumer.Data(context.Background())
 				g.Expect(err).ShouldNot(HaveOccurred())
 				g.Expect(d).ShouldNot(BeNil())

--- a/suite/contracts/contracts_test.go
+++ b/suite/contracts/contracts_test.go
@@ -21,6 +21,7 @@ var _ = Describe("Basic Contract Interactions @contract", func() {
 			var err error
 			s, err = actions.DefaultLocalSetup(
 				"basic-chainlink",
+				nil,
 				environment.NewChainlinkCluster(0),
 				client.NewNetworkFromConfig,
 				tools.ProjectRoot,

--- a/suite/contracts/contracts_vrf_test.go
+++ b/suite/contracts/contracts_vrf_test.go
@@ -30,6 +30,7 @@ var _ = Describe("VRF suite @vrf", func() {
 		By("Deploying the environment", func() {
 			s, err = actions.DefaultLocalSetup(
 				"basic-chainlink",
+				nil,
 				environment.NewChainlinkCluster(1),
 				client.NewNetworkFromConfig,
 				tools.ProjectRoot,
@@ -106,7 +107,7 @@ var _ = Describe("VRF suite @vrf", func() {
 			err = consumer.RequestRandomness(s.Wallets.Default(), requestHash, big.NewInt(1))
 			Expect(err).ShouldNot(HaveOccurred())
 
-			Eventually(func(g Gomega){
+			Eventually(func(g Gomega) {
 				out, err := consumer.RandomnessOutput(context.Background())
 				g.Expect(err).ShouldNot(HaveOccurred())
 				g.Expect(out.Uint64()).Should(Not(BeNumerically("==", 0)))

--- a/suite/performance/flux_test.go
+++ b/suite/performance/flux_test.go
@@ -26,6 +26,7 @@ var _ = Describe("Performance tests", func() {
 		By("Deploying the environment", func() {
 			s, err = actions.DefaultLocalSetup(
 				"basic-chainlink",
+				nil,
 				environment.NewChainlinkCluster(numberOfNodes),
 				client.NewNetworkFromConfigWithDefault(client.NetworkGethPerformance),
 				tools.ProjectRoot,

--- a/suite/performance/keeper_test.go
+++ b/suite/performance/keeper_test.go
@@ -24,6 +24,7 @@ var _ = Describe("Keeper performance test @performance-keeper", func() {
 		By("Deploying the environment", func() {
 			suiteSetup, err = actions.DefaultLocalSetup(
 				"keeper-soak",
+				nil,
 				environment.NewChainlinkCluster(5),
 				client.NewNetworkFromConfig,
 				tools.ProjectRoot,

--- a/suite/performance/ocr_test.go
+++ b/suite/performance/ocr_test.go
@@ -25,6 +25,7 @@ var _ = Describe("OCR soak test @soak-ocr", func() {
 		By("Deploying the environment", func() {
 			s, err = actions.DefaultLocalSetup(
 				"ocr-soak",
+				environment.PerfTestEnvLabelsMap,
 				environment.NewChainlinkCluster(5),
 				client.NewNetworkFromConfig,
 				tools.ProjectRoot,

--- a/suite/performance/runlog_test.go
+++ b/suite/performance/runlog_test.go
@@ -24,6 +24,7 @@ var _ = Describe("Runlog soak test @soak-runlog", func() {
 		By("Deploying the environment", func() {
 			suiteSetup, err = actions.DefaultLocalSetup(
 				"runlog-soak",
+				environment.PerfTestEnvLabelsMap,
 				// no need more than one node for runlog test
 				environment.NewChainlinkCluster(1),
 				client.NewNetworkFromConfig,

--- a/suite/performance/vrf_test.go
+++ b/suite/performance/vrf_test.go
@@ -24,6 +24,7 @@ var _ = Describe("VRF soak test @soak-vrf", func() {
 		By("Deploying the environment", func() {
 			suiteSetup, err = actions.DefaultLocalSetup(
 				"vrf-soak",
+				environment.PerfTestEnvLabelsMap,
 				// more than one node is useless for VRF, because nodes are not cooperating for randomness
 				environment.NewChainlinkCluster(1),
 				client.NewNetworkFromConfig,
@@ -55,7 +56,7 @@ var _ = Describe("VRF soak test @soak-vrf", func() {
 						NumberOfContracts: 30,
 					},
 					RoundTimeout: 60 * time.Second,
-					TestDuration: 3 * time.Minute,
+					TestDuration: 30 * time.Minute,
 				},
 				suiteSetup.Env,
 				suiteSetup.Link,

--- a/suite/refill/eth_refill_test.go
+++ b/suite/refill/eth_refill_test.go
@@ -33,6 +33,7 @@ var _ = Describe("FluxAggregator ETH Refill @refill", func() {
 		By("Deploying the environment", func() {
 			s, err = actions.DefaultLocalSetup(
 				"basic-chainlink",
+				nil,
 				environment.NewChainlinkCluster(3),
 				client.NewNetworkFromConfig,
 				tools.ProjectRoot,

--- a/suite/testcommon/ocr.go
+++ b/suite/testcommon/ocr.go
@@ -32,6 +32,7 @@ func DeployOCRForEnv(i *OCRSetupInputs, envName string, envInit environment.K8sE
 		var err error
 		i.SuiteSetup, err = actions.DefaultLocalSetup(
 			envName,
+			nil,
 			envInit,
 			client.NewNetworkFromConfig,
 			tools.ProjectRoot,

--- a/suite/testcommon/runlog.go
+++ b/suite/testcommon/runlog.go
@@ -35,6 +35,7 @@ func SetupRunlogEnv(i *RunlogSetupInputs) {
 	By("Deploying the environment", func() {
 		i.S, i.Err = actions.DefaultLocalSetup(
 			"basic-chainlink",
+			nil,
 			environment.NewChainlinkCluster(1),
 			client.NewNetworkFromConfig,
 			tools.ProjectRoot,
@@ -117,7 +118,7 @@ func CallRunlogOracle(i *RunlogSetupInputs) {
 // CheckRunlogCompleted checks if oracle send the data on chain
 func CheckRunlogCompleted(i *RunlogSetupInputs) {
 	By("receives API call data on-chain", func() {
-		Eventually(func(g Gomega){
+		Eventually(func(g Gomega) {
 			d, err := i.Consumer.Data(context.Background())
 			g.Expect(err).ShouldNot(HaveOccurred())
 			g.Expect(d).ShouldNot(BeNil())


### PR DESCRIPTION
A service to clean-up different stale test environments that are panicked in CI or stuck for some other reason
You can add to one of your tests labels, for example:
```
       BasicTestEnvLabelsMap = map[string]string{
		"type":    "test",
		"policy":  "timeout",
		"timeout": "20m",
	}
```
```
actions.DefaultLocalSetup(
    "basic-chainlink",
    environment.BasicTestEnvLabelsMap,
    environment.NewChainlinkCluster(1),
    client.NewNetworkFromConfig,
    tools.ProjectRoot,
)
```
See `README.md` in PR for updating image and installing into cluster.
Also you can check it outside of a cluster:
```
make test_cleaner
```

Timeout for integration tests is set to `20m`, for perf it's `6h` in that PR
In `KEEP_ENVIRONMENTS="Always | OnFail"` policies are ignored