### PR TITLE
OCRSetupInputs multiple contracts

### DIFF
--- a/suite/chaos/chaos_ocr_test.go
+++ b/suite/chaos/chaos_ocr_test.go
@@ -20,7 +20,7 @@ var _ = XDescribeTable("OCR chaos tests @chaos-ocr", func(
 	Context("Runs OCR test with a chaos modifier", func() {
 		testcommon.DeployOCRForEnv(i, envInit)
 		testcommon.FundNodes(i)
-		testcommon.DeployContracts(i, 1)
+		testcommon.DeployOCRContracts(i, 1)
 		testcommon.SendOCRJobs(i)
 		_, err := i.SuiteSetup.Environment().ApplyChaos(chaosSpec)
 		Expect(err).ShouldNot(HaveOccurred())

--- a/suite/chaos/chaos_ocr_test.go
+++ b/suite/chaos/chaos_ocr_test.go
@@ -19,7 +19,8 @@ var _ = XDescribeTable("OCR chaos tests @chaos-ocr", func(
 	i := &testcommon.OCRSetupInputs{}
 	Context("Runs OCR test with a chaos modifier", func() {
 		testcommon.DeployOCRForEnv(i, envInit)
-		testcommon.SetupOCRTest(i)
+		testcommon.FundNodes(i)
+		testcommon.DeployContracts(i, 1)
 		testcommon.SendOCRJobs(i)
 		_, err := i.SuiteSetup.Environment().ApplyChaos(chaosSpec)
 		Expect(err).ShouldNot(HaveOccurred())

--- a/suite/contracts/contracts_ocr_test.go
+++ b/suite/contracts/contracts_ocr_test.go
@@ -14,6 +14,7 @@ var _ = Describe("OCR Feed @ocr", func() {
 	) {
 		i := &testcommon.OCRSetupInputs{}
 		testcommon.DeployOCRForEnv(i, envInit)
+		testcommon.FundNodes(i)
 		testcommon.DeployContracts(i, 1)
 		testcommon.SendOCRJobs(i)
 		testcommon.CheckRound(i)

--- a/suite/contracts/contracts_ocr_test.go
+++ b/suite/contracts/contracts_ocr_test.go
@@ -15,7 +15,7 @@ var _ = Describe("OCR Feed @ocr", func() {
 		i := &testcommon.OCRSetupInputs{}
 		testcommon.DeployOCRForEnv(i, envInit)
 		testcommon.FundNodes(i)
-		testcommon.DeployContracts(i, 1)
+		testcommon.DeployOCRContracts(i, 1)
 		testcommon.SendOCRJobs(i)
 		testcommon.CheckRound(i)
 		By("Printing gas stats", func() {

--- a/suite/contracts/contracts_ocr_test.go
+++ b/suite/contracts/contracts_ocr_test.go
@@ -14,7 +14,7 @@ var _ = Describe("OCR Feed @ocr", func() {
 	) {
 		i := &testcommon.OCRSetupInputs{}
 		testcommon.DeployOCRForEnv(i, envInit)
-		testcommon.SetupOCRTest(i)
+		testcommon.DeployContracts(i, 1)
 		testcommon.SendOCRJobs(i)
 		testcommon.CheckRound(i)
 		By("Printing gas stats", func() {

--- a/suite/steps/alerts_steps.go
+++ b/suite/steps/alerts_steps.go
@@ -1,20 +1,26 @@
 package steps
 
 import (
+	"fmt"
 	. "github.com/onsi/gomega"
 	"github.com/smartcontractkit/integrations-framework/client"
+	"github.com/smartcontractkit/integrations-framework/contracts"
 )
 
-// GetMockserverInitializerDataForOTPE crates mocked weiwatchers data needed for otpe
-func GetMockserverInitializerDataForOTPE(offChainAggregatorInstanceAddress string, chainlinkNodes []client.Chainlink) interface{} {
-	contractInfo := client.ContractInfoJSON{
-		ContractVersion: 4,
-		Path:            "test",
-		Status:          "live",
-		ContractAddress: offChainAggregatorInstanceAddress,
-	}
+// GetMockserverInitializerDataForOTPE creates mocked weiwatchers data needed for otpe
+func GetMockserverInitializerDataForOTPE(OCRInstances   []contracts.OffchainAggregator, chainlinkNodes []client.Chainlink) interface{} {
+	var contractsInfo []client.ContractInfoJSON
 
-	contractsInfo := []client.ContractInfoJSON{contractInfo}
+	for index, OCRInstance := range OCRInstances {
+		contractInfo := client.ContractInfoJSON{
+			ContractVersion: 4,
+			Path:            fmt.Sprintf("contract_%d", index),
+			Status:          "live",
+			ContractAddress: OCRInstance.Address(),
+		}
+
+		contractsInfo = append(contractsInfo, contractInfo)
+	}
 
 	contractsInitializer := client.HttpInitializer{
 		Request:  client.HttpRequest{Path: "/contracts.json"},

--- a/suite/steps/alerts_steps.go
+++ b/suite/steps/alerts_steps.go
@@ -8,7 +8,7 @@ import (
 )
 
 // GetMockserverInitializerDataForOTPE creates mocked weiwatchers data needed for otpe
-func GetMockserverInitializerDataForOTPE(OCRInstances   []contracts.OffchainAggregator, chainlinkNodes []client.Chainlink) interface{} {
+func GetMockserverInitializerDataForOTPE(OCRInstances []contracts.OffchainAggregator, chainlinkNodes []client.Chainlink) interface{} {
 	var contractsInfo []client.ContractInfoJSON
 
 	for index, OCRInstance := range OCRInstances {

--- a/suite/testcommon/ocr.go
+++ b/suite/testcommon/ocr.go
@@ -50,6 +50,7 @@ func DeployOCRForEnv(i *OCRSetupInputs, envInit environment.K8sEnvSpecInit) {
 	})
 }
 
+// DeployContracts deploys and funds a certain number of offchain aggregator contracts
 func DeployContracts(i *OCRSetupInputs, nrOfOCRContracts int) {
 	deployer, err := contracts.NewContractDeployer(i.NetworkInfo.Client)
 	Expect(err).ShouldNot(HaveOccurred())
@@ -71,6 +72,7 @@ func DeployContracts(i *OCRSetupInputs, nrOfOCRContracts int) {
 	}
 }
 
+// FundNodes funds all chainlink nodes
 func FundNodes(i *OCRSetupInputs) {
 	ethAmount, err := i.NetworkInfo.Deployer.CalculateETHForTXs(i.NetworkInfo.Wallets.Default(), i.NetworkInfo.Network.Config(), 2)
 	Expect(err).ShouldNot(HaveOccurred())
@@ -197,7 +199,7 @@ func SetAdapterResults(i *OCRSetupInputs, results []int) {
 
 	log.Info().Interface("New Adapter results", results).Msg("Setting new values")
 
-	for OCRInstanceIndex, _ := range i.OCRInstances {
+	for OCRInstanceIndex := range i.OCRInstances {
 		for nodeIndex := 1; nodeIndex < len(i.ChainlinkNodes); nodeIndex++ {
 			pathSelector := client.PathSelector{Path: fmt.Sprintf("/node_%d_contract_%d", nodeIndex, OCRInstanceIndex)}
 			err := i.Mockserver.ClearExpectation(pathSelector)
@@ -207,7 +209,7 @@ func SetAdapterResults(i *OCRSetupInputs, results []int) {
 	}
 	var initializers []client.HttpInitializer
 
-	for OCRInstanceIndex, _ := range i.OCRInstances {
+	for OCRInstanceIndex := range i.OCRInstances {
 		for nodeIndex := 1; nodeIndex < len(i.ChainlinkNodes); nodeIndex++ {
 			adResp := client.AdapterResponse{
 				Id:    "",

--- a/suite/testcommon/ocr.go
+++ b/suite/testcommon/ocr.go
@@ -50,8 +50,8 @@ func DeployOCRForEnv(i *OCRSetupInputs, envInit environment.K8sEnvSpecInit) {
 	})
 }
 
-// DeployContracts deploys and funds a certain number of offchain aggregator contracts
-func DeployContracts(i *OCRSetupInputs, nrOfOCRContracts int) {
+// DeployOCRContracts deploys and funds a certain number of offchain aggregator contracts
+func DeployOCRContracts(i *OCRSetupInputs, nrOfOCRContracts int) {
 	deployer, err := contracts.NewContractDeployer(i.NetworkInfo.Client)
 	Expect(err).ShouldNot(HaveOccurred())
 
@@ -235,7 +235,7 @@ func NewOCRSetupInputForObservability(i *OCRSetupInputs, nodeCount int, contract
 		environment.NewChainlinkClusterForObservabilityTesting(nodeCount),
 	)
 	FundNodes(i)
-	DeployContracts(i, contractCount)
+	DeployOCRContracts(i, contractCount)
 
 	err := i.Mockserver.PutExpectations(steps.GetMockserverInitializerDataForOTPE(
 		i.OCRInstances,

--- a/suite/testcommon/ocr.go
+++ b/suite/testcommon/ocr.go
@@ -25,7 +25,7 @@ type OCRSetupInputs struct {
 	NetworkInfo    actions.NetworkInfo
 	ChainlinkNodes []client.Chainlink
 	DefaultWallet  client.BlockchainWallet
-	OCRInstance    contracts.OffchainAggregator
+	OCRInstances   []contracts.OffchainAggregator
 	Mockserver     *client.MockserverClient
 }
 
@@ -50,83 +50,86 @@ func DeployOCRForEnv(i *OCRSetupInputs, envInit environment.K8sEnvSpecInit) {
 	})
 }
 
-// SetupOCRTest setup for an ocr test
-func SetupOCRTest(i *OCRSetupInputs) {
-	By("Funding nodes and deploying OCR contract", func() {
-		ethAmount, err := i.NetworkInfo.Deployer.CalculateETHForTXs(i.NetworkInfo.Wallets.Default(), i.NetworkInfo.Network.Config(), 2)
-		Expect(err).ShouldNot(HaveOccurred())
-		err = actions.FundChainlinkNodes(
-			i.ChainlinkNodes,
-			i.NetworkInfo.Client,
-			i.DefaultWallet,
-			ethAmount,
-			big.NewFloat(2),
-		)
-		Expect(err).ShouldNot(HaveOccurred())
+func DeployContracts(i *OCRSetupInputs, nrOfOCRContracts int) {
+	deployer, err := contracts.NewContractDeployer(i.NetworkInfo.Client)
+	Expect(err).ShouldNot(HaveOccurred())
 
-		// Deploy and config OCR contract
-		deployer, err := contracts.NewContractDeployer(i.NetworkInfo.Client)
+	for nr := 0; nr < nrOfOCRContracts; nr++ {
+		OCRInstance, err := deployer.DeployOffChainAggregator(i.DefaultWallet, contracts.DefaultOffChainAggregatorOptions())
 		Expect(err).ShouldNot(HaveOccurred())
-
-		i.OCRInstance, err = deployer.DeployOffChainAggregator(i.DefaultWallet, contracts.DefaultOffChainAggregatorOptions())
-		Expect(err).ShouldNot(HaveOccurred())
-		err = i.OCRInstance.SetConfig(
+		err = OCRInstance.SetConfig(
 			i.DefaultWallet,
 			i.ChainlinkNodes[1:],
 			contracts.DefaultOffChainAggregatorConfig(len(i.ChainlinkNodes[1:])),
 		)
 		Expect(err).ShouldNot(HaveOccurred())
-		err = i.OCRInstance.Fund(i.DefaultWallet, nil, big.NewFloat(2))
+		err = OCRInstance.Fund(i.DefaultWallet, nil, big.NewFloat(2))
 		Expect(err).ShouldNot(HaveOccurred())
 		err = i.NetworkInfo.Client.WaitForEvents()
 		Expect(err).ShouldNot(HaveOccurred())
-	})
+		i.OCRInstances = append(i.OCRInstances, OCRInstance)
+	}
+}
+
+func FundNodes(i *OCRSetupInputs) {
+	ethAmount, err := i.NetworkInfo.Deployer.CalculateETHForTXs(i.NetworkInfo.Wallets.Default(), i.NetworkInfo.Network.Config(), 2)
+	Expect(err).ShouldNot(HaveOccurred())
+	err = actions.FundChainlinkNodes(
+		i.ChainlinkNodes,
+		i.NetworkInfo.Client,
+		i.DefaultWallet,
+		ethAmount,
+		big.NewFloat(2),
+	)
+	Expect(err).ShouldNot(HaveOccurred())
 }
 
 // SendOCRJobs bootstraps the first node and to the other nodes sends ocr jobs that
 // read from different adapters
 func SendOCRJobs(i *OCRSetupInputs) {
 	By("Sending OCR jobs to chainlink nodes", func() {
-		bootstrapNode := i.ChainlinkNodes[0]
-		bootstrapP2PIds, err := bootstrapNode.ReadP2PKeys()
-		Expect(err).ShouldNot(HaveOccurred())
-		bootstrapP2PId := bootstrapP2PIds.Data[0].Attributes.PeerID
-		bootstrapSpec := &client.OCRBootstrapJobSpec{
-			ContractAddress: i.OCRInstance.Address(),
-			P2PPeerID:       bootstrapP2PId,
-			IsBootstrapPeer: true,
-		}
-		_, err = bootstrapNode.CreateJob(bootstrapSpec)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		for index := 1; index < len(i.ChainlinkNodes); index++ {
-			nodeP2PIds, err := i.ChainlinkNodes[index].ReadP2PKeys()
+		for OCRInstanceIndex, OCRInstance := range i.OCRInstances {
+			bootstrapNode := i.ChainlinkNodes[0]
+			bootstrapP2PIds, err := bootstrapNode.ReadP2PKeys()
 			Expect(err).ShouldNot(HaveOccurred())
-			nodeP2PId := nodeP2PIds.Data[0].Attributes.PeerID
-			nodeTransmitterAddress, err := i.ChainlinkNodes[index].PrimaryEthAddress()
-			Expect(err).ShouldNot(HaveOccurred())
-			nodeOCRKeys, err := i.ChainlinkNodes[index].ReadOCRKeys()
-			Expect(err).ShouldNot(HaveOccurred())
-			nodeOCRKeyId := nodeOCRKeys.Data[0].ID
-
-			bta := client.BridgeTypeAttributes{
-				Name: fmt.Sprintf("node_%d", index),
-				URL:  fmt.Sprintf("%s/node_%d", i.Mockserver.Config.ClusterURL, index),
+			bootstrapP2PId := bootstrapP2PIds.Data[0].Attributes.PeerID
+			bootstrapSpec := &client.OCRBootstrapJobSpec{
+				ContractAddress: OCRInstance.Address(),
+				P2PPeerID:       bootstrapP2PId,
+				IsBootstrapPeer: true,
 			}
-
-			err = i.ChainlinkNodes[index].CreateBridge(&bta)
+			_, err = bootstrapNode.CreateJob(bootstrapSpec)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			ocrSpec := &client.OCRTaskJobSpec{
-				ContractAddress:    i.OCRInstance.Address(),
-				P2PPeerID:          nodeP2PId,
-				P2PBootstrapPeers:  []client.Chainlink{bootstrapNode},
-				KeyBundleID:        nodeOCRKeyId,
-				TransmitterAddress: nodeTransmitterAddress,
-				ObservationSource:  client.ObservationSourceSpecBridge(bta),
+			for nodeIndex := 1; nodeIndex < len(i.ChainlinkNodes); nodeIndex++ {
+				nodeP2PIds, err := i.ChainlinkNodes[nodeIndex].ReadP2PKeys()
+				Expect(err).ShouldNot(HaveOccurred())
+				nodeP2PId := nodeP2PIds.Data[0].Attributes.PeerID
+				nodeTransmitterAddress, err := i.ChainlinkNodes[nodeIndex].PrimaryEthAddress()
+				Expect(err).ShouldNot(HaveOccurred())
+				nodeOCRKeys, err := i.ChainlinkNodes[nodeIndex].ReadOCRKeys()
+				Expect(err).ShouldNot(HaveOccurred())
+				nodeOCRKeyId := nodeOCRKeys.Data[0].ID
+
+				bta := client.BridgeTypeAttributes{
+					Name: fmt.Sprintf("node_%d_contract_%d", nodeIndex, OCRInstanceIndex),
+					URL:  fmt.Sprintf("%s/node_%d_contract_%d", i.Mockserver.Config.ClusterURL, nodeIndex, OCRInstanceIndex),
+				}
+
+				err = i.ChainlinkNodes[nodeIndex].CreateBridge(&bta)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				ocrSpec := &client.OCRTaskJobSpec{
+					ContractAddress:    OCRInstance.Address(),
+					P2PPeerID:          nodeP2PId,
+					P2PBootstrapPeers:  []client.Chainlink{bootstrapNode},
+					KeyBundleID:        nodeOCRKeyId,
+					TransmitterAddress: nodeTransmitterAddress,
+					ObservationSource:  client.ObservationSourceSpecBridge(bta),
+				}
+				_, err = i.ChainlinkNodes[nodeIndex].CreateJob(ocrSpec)
+				Expect(err).ShouldNot(HaveOccurred())
 			}
-			_, err = i.ChainlinkNodes[index].CreateJob(ocrSpec)
-			Expect(err).ShouldNot(HaveOccurred())
 		}
 	})
 }
@@ -145,9 +148,11 @@ func CheckRound(i *OCRSetupInputs) {
 		StartNewRound(i, 1)
 
 		// Check answer is as expected
-		answer, err := i.OCRInstance.GetLatestAnswer(context.Background())
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(answer.Int64()).Should(Equal(int64(5)), "Latest answer from OCR is not as expected")
+		for _, OCRInstance := range i.OCRInstances {
+			answer, err := OCRInstance.GetLatestAnswer(context.Background())
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(answer.Int64()).Should(Equal(int64(5)), "Latest answer from OCR is not as expected")
+		}
 
 		// Change adapters answer to 10
 		adapterResults = []int{}
@@ -160,26 +165,29 @@ func CheckRound(i *OCRSetupInputs) {
 		StartNewRound(i, 2)
 
 		// Check answer is as expected
-		answer, err = i.OCRInstance.GetLatestAnswer(context.Background())
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(answer.Int64()).Should(Equal(int64(10)), "Latest answer from OCR is not as expected")
+		for _, OCRInstance := range i.OCRInstances {
+			answer, err := OCRInstance.GetLatestAnswer(context.Background())
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(answer.Int64()).Should(Equal(int64(10)), "Latest answer from OCR is not as expected")
+		}
 	})
 }
 
 // StartNewRound requests a new round from the ocr contract and waits for confirmation
 func StartNewRound(i *OCRSetupInputs, roundNr int64) {
 	roundTimeout := time.Minute * 2
+	for _, OCRInstance := range i.OCRInstances {
+		err := OCRInstance.RequestNewRound(i.DefaultWallet)
+		Expect(err).ShouldNot(HaveOccurred())
+		err = i.SuiteSetup.DefaultNetwork().Client.WaitForEvents()
+		Expect(err).ShouldNot(HaveOccurred())
 
-	err := i.OCRInstance.RequestNewRound(i.DefaultWallet)
-	Expect(err).ShouldNot(HaveOccurred())
-	err = i.SuiteSetup.DefaultNetwork().Client.WaitForEvents()
-	Expect(err).ShouldNot(HaveOccurred())
-
-	// Wait for the second round
-	ocrRound := contracts.NewOffchainAggregatorRoundConfirmer(i.OCRInstance, big.NewInt(roundNr), roundTimeout)
-	i.SuiteSetup.DefaultNetwork().Client.AddHeaderEventSubscription(i.OCRInstance.Address(), ocrRound)
-	err = i.SuiteSetup.DefaultNetwork().Client.WaitForEvents()
-	Expect(err).ShouldNot(HaveOccurred())
+		// Wait for the second round
+		ocrRound := contracts.NewOffchainAggregatorRoundConfirmer(OCRInstance, big.NewInt(roundNr), roundTimeout)
+		i.SuiteSetup.DefaultNetwork().Client.AddHeaderEventSubscription(OCRInstance.Address(), ocrRound)
+		err = i.SuiteSetup.DefaultNetwork().Client.WaitForEvents()
+		Expect(err).ShouldNot(HaveOccurred())
+	}
 }
 
 // SetAdapterResults sets the mock responses in mockserver that are read by chainlink nodes
@@ -189,24 +197,29 @@ func SetAdapterResults(i *OCRSetupInputs, results []int) {
 
 	log.Info().Interface("New Adapter results", results).Msg("Setting new values")
 
-	for index := 1; index < len(i.ChainlinkNodes); index++ {
-		pathSelector := client.PathSelector{Path: fmt.Sprintf("/node_%d", index)}
-		err := i.Mockserver.ClearExpectation(pathSelector)
-		Expect(err).ShouldNot(HaveOccurred())
-	}
+	for OCRInstanceIndex, _ := range i.OCRInstances {
+		for nodeIndex := 1; nodeIndex < len(i.ChainlinkNodes); nodeIndex++ {
+			pathSelector := client.PathSelector{Path: fmt.Sprintf("/node_%d_contract_%d", nodeIndex, OCRInstanceIndex)}
+			err := i.Mockserver.ClearExpectation(pathSelector)
+			Expect(err).ShouldNot(HaveOccurred())
+		}
 
+	}
 	var initializers []client.HttpInitializer
-	for index := 1; index < len(i.ChainlinkNodes); index++ {
-		adResp := client.AdapterResponse{
-			Id:    "",
-			Data:  client.AdapterResult{Result: results[index-1]},
-			Error: nil,
+
+	for OCRInstanceIndex, _ := range i.OCRInstances {
+		for nodeIndex := 1; nodeIndex < len(i.ChainlinkNodes); nodeIndex++ {
+			adResp := client.AdapterResponse{
+				Id:    "",
+				Data:  client.AdapterResult{Result: results[nodeIndex-1]},
+				Error: nil,
+			}
+			nodesInitializer := client.HttpInitializer{
+				Request:  client.HttpRequest{Path: fmt.Sprintf("/node_%d_contract_%d", nodeIndex, OCRInstanceIndex)},
+				Response: client.HttpResponse{Body: adResp},
+			}
+			initializers = append(initializers, nodesInitializer)
 		}
-		nodesInitializer := client.HttpInitializer{
-			Request:  client.HttpRequest{Path: fmt.Sprintf("/node_%d", index)},
-			Response: client.HttpResponse{Body: adResp},
-		}
-		initializers = append(initializers, nodesInitializer)
 	}
 
 	err := i.Mockserver.PutExpectations(initializers)
@@ -214,15 +227,16 @@ func SetAdapterResults(i *OCRSetupInputs, results []int) {
 }
 
 // NewOCRSetupInputForObservability deploys and setups env and clients for testing observability
-func NewOCRSetupInputForObservability(i *OCRSetupInputs, nodeCount int, rules map[string]*os.File) {
+func NewOCRSetupInputForObservability(i *OCRSetupInputs, nodeCount int, contractCount int, rules map[string]*os.File) {
 	DeployOCRForEnv(
 		i,
 		environment.NewChainlinkClusterForObservabilityTesting(nodeCount),
 	)
-	SetupOCRTest(i)
+	FundNodes(i)
+	DeployContracts(i, contractCount)
 
 	err := i.Mockserver.PutExpectations(steps.GetMockserverInitializerDataForOTPE(
-		i.OCRInstance.Address(),
+		i.OCRInstances,
 		i.ChainlinkNodes,
 	))
 	Expect(err).ShouldNot(HaveOccurred())


### PR DESCRIPTION
In order to test the `Oracle not making observations on an OCR feed` alert I need to deploy more than one OCR contract with the same set of nodes