### PR TITLE
update ocr2 OnChainSigningAddress => OnChainPublicKey naming

### DIFF
--- a/client/chainlink_models.go
+++ b/client/chainlink_models.go
@@ -175,10 +175,10 @@ type OCR2KeyData struct {
 
 // OCR2KeyAttributes is the model that represents the created OCR2 keys when read
 type OCR2KeyAttributes struct {
-	ChainType             string `json:"chainType"`
-	ConfigPublicKey       string `json:"configPublicKey"`
-	OffChainPublicKey     string `json:"offChainPublicKey"`
-	OnChainSigningAddress string `json:"onChainSigningAddress"`
+	ChainType         string `json:"chainType"`
+	ConfigPublicKey   string `json:"configPublicKey"`
+	OffChainPublicKey string `json:"offChainPublicKey"`
+	OnChainPublicKey  string `json:"onchainPublicKey"`
 }
 
 // P2PKeys is the model that represents the created P2P keys when read

--- a/client/chainlink_test.go
+++ b/client/chainlink_test.go
@@ -227,10 +227,10 @@ var _ = Describe("Chainlink @unit", func() {
 			ocrKeyData := OCR2KeyData{
 				ID: "1",
 				Attributes: OCR2KeyAttributes{
-					ChainType:             chain,
-					ConfigPublicKey:       "someNon3sens3",
-					OffChainPublicKey:     "mor3Non3sens3",
-					OnChainSigningAddress: "thisActuallyMak3sS3ns3",
+					ChainType:         chain,
+					ConfigPublicKey:   "someNon3sens3",
+					OffChainPublicKey: "mor3Non3sens3",
+					OnChainPublicKey:  "thisActuallyMak3sS3ns3",
 				},
 			}
 			server := mockedServer(func(rw http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
Recent change in core changed the naming for `onchainSigningAddress` to `onchainPublicKey` which is a more appropriate name since OCR2 supports more than ETH

Related PR: https://github.com/smartcontractkit/chainlink/pull/5649