### PR TITLE
Add make install_tools command to install more of what is needed to run the project for make

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,18 +24,12 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go1-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-
-      - name: Download Go Vendor Packages
+            ${{ runner.os }}-go1-
+      - name: Download Go Vendor Packages and Ginkgo
         if: steps.cache-packages.outputs.cache-hit != 'true'
-        run: go mod download
-      - name: Install Ginkgo CLI
-        run: |
-          go get github.com/onsi/ginkgo/v2/ginkgo/generators@v2.1.2
-          go get github.com/onsi/ginkgo/v2/ginkgo/internal@v2.1.2
-          go get github.com/onsi/ginkgo/v2/ginkgo/labels@v2.1.2
-          go install github.com/onsi/ginkgo/v2/ginkgo
+        run: make install_ci
       - name: Run Tests
         run: |
           export PATH=$PATH:$(go env GOPATH)/bin

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,9 +24,10 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go1-${{ hashFiles('**/go.sum') }}
+            ~/go/bin
+          key: ${{ runner.os }}-go2-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go1-
+            ${{ runner.os }}-go2-
       - name: Download Go Vendor Packages and Ginkgo
         if: steps.cache-packages.outputs.cache-hit != 'true'
         run: make install_ci

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
-golang 1.17.6
+golang 1.17.8
 nodejs 14.19.0
+ginkgo 2.1.2

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,22 @@ BIN_DIR = bin
 export GOPATH ?= $(shell go env GOPATH)
 export GO111MODULE ?= on
 
+LINUX=LINUX
+OSX=OSX
+WINDOWS=WIN32
+OSFLAG :=
+ifeq ($(OS),Windows_NT)
+	OSFLAG = $(WINDOWS)
+else
+	UNAME_S := $(shell uname -s)
+	ifeq ($(UNAME_S),Linux)
+		OSFLAG = $(LINUX)
+	endif
+	ifeq ($(UNAME_S),Darwin)
+		OSFLAG = $(OSX)
+	endif
+endif
+
 lint:
 	${BIN_DIR}/golangci-lint --color=always run ./... -v
 
@@ -11,7 +27,26 @@ golangci:
 go_mod:
 	go mod download
 
-install: go_mod golangci
+install_tools:
+ifeq ($(OSFLAG),$(LINUX))
+	# used for linux and ci
+	go install github.com/onsi/ginkgo/v2/ginkgo@v$(shell cat ./.tool-versions | grep ginkgo | sed -En "s/ginkgo.(.*)/\1/p")
+endif
+ifeq ($(OSFLAG),$(WINDOWS))
+	echo "If you are running windows and know how to install what is needed, please contribute by adding it here!"
+	exit 1
+endif
+ifeq ($(OSFLAG),$(OSX))
+	brew install asdf
+	asdf plugin-add nodejs https://github.com/asdf-vm/asdf-nodejs.git || true
+	asdf plugin-add golang https://github.com/kennyp/asdf-golang.git || true
+	asdf plugin-add ginkgo https://github.com/jimmidyson/asdf-ginkgo.git || true
+	asdf install
+endif
+
+install: go_mod golangci install_tools
+
+install_ci: go_mod install_tools
 
 compile_contracts:
 	python3 ./utils/compile_contracts.py


### PR DESCRIPTION
- Add install tools that will run differently for different operating systems
- If in the future we move to nix for linux/ci we can put it there
- And if we ever have someone on a windows box they can add the instructions in here as well
- Bumped the versions in asdf
- Use make call in ci