### PR TITLE
Klaytn network fixes

### DIFF
--- a/client/ethereum.go
+++ b/client/ethereum.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/big"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -593,6 +594,12 @@ func (e *EthereumClient) DeployContract(
 	}
 	gasPriceBuffer := big.NewInt(0).SetUint64(e.NetworkConfig.GasEstimationBuffer)
 	opts.GasTipCap = suggestedTipCap.Add(gasPriceBuffer, suggestedTipCap)
+
+	// Kludge for Klatyn implementation
+	if strings.Contains(strings.ToLower(e.NetworkConfig.ID), "klaytn") {
+		opts.GasTipCap = opts.GasPrice
+	}
+
 	contractAddress, transaction, contractInstance, err := deployer(opts, e.Client)
 	if err != nil {
 		return nil, nil, nil, err

--- a/docs/writing-a-test/soak.md
+++ b/docs/writing-a-test/soak.md
@@ -49,7 +49,7 @@ Modify these values that make sense for the tests you want to run. Once the valu
 The rest of the `remote_runner_config.yaml` file holds various Slack bot params to notify you when the test finishes.
 
 ```yaml
-slack_api_key: abcdefg # A Slack API key to upload test results with. This API Key needs to have `file:write` permissions
+slack_api_key: abcdefg # A Slack API key to upload test results with. This should be the `Bot User OAuth Token` 
 slack_channel: C01xxxxx # The Slack Channel ID (open your Slack channel details and copy the ID there)
 slack_user_id: U01xxxxx # Your Slack member ID https://zapier.com/help/doc/common-problems-slack
 ```

--- a/suite/smoke/vrf_test.go
+++ b/suite/smoke/vrf_test.go
@@ -76,6 +76,9 @@ var _ = Describe("VRF suite @vrf", func() {
 			Expect(err).ShouldNot(HaveOccurred(), "Deploying VRF coordinator shouldn't fail")
 			consumer, err = cd.DeployVRFConsumer(lt.Address(), coordinator.Address())
 			Expect(err).ShouldNot(HaveOccurred(), "Deploying VRF consumer contract shouldn't fail")
+			err = nets.Default.WaitForEvents()
+			Expect(err).ShouldNot(HaveOccurred(), "Failed to wait for VRF setup contracts to deploy")
+
 			err = lt.Transfer(consumer.Address(), big.NewInt(2e18))
 			Expect(err).ShouldNot(HaveOccurred(), "Funding consumer contract shouldn't fail")
 			_, err = cd.DeployVRFContract()


### PR DESCRIPTION
1. Always set gas tip cap equal to gas price for Klaytn
2. Close OCR round completed event channel once event was handled, to prevent event doubling and test failng